### PR TITLE
[BUGFIX] Standard path is Documentation not Documents

### DIFF
--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Screenshots.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Screenshots.php
@@ -23,7 +23,7 @@ class Typo3Screenshots extends Module
     protected $config = [
         'actionsIdFilter' => '',
         'basePath' => '',
-        'documentationPath' => 'Documents',
+        'documentationPath' => 'Documentation',
         'imagePath' => 'Images/AutomaticScreenshots',
         'rstPath' => 'Images/Rst',
         'createRstFile' => true


### PR DESCRIPTION
depends on https://github.com/TYPO3-Documentation/t3docs-screenshots/pull/29