### PR TITLE
[FEATURE] Show field path as nested array in code snippet

### DIFF
--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3CodeSnippets.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3CodeSnippets.php
@@ -131,11 +131,24 @@ class Typo3CodeSnippets extends Module
         if ($field === '') {
             $code = ArrayUtility::arrayExport($phpArray);
         } else {
+            $fields = array_reverse(explode ( '/' , $field));
+            $valueExport = ArrayUtility::getValueByPath($phpArray, $field);
+            if (sizeof($fields) > 1) {
+                for ($i = 0; $i < sizeof($fields)-1; $i++) {
+                    $valueExport = [$fields[$i] => $valueExport];
+                }
+            }
             $code = sprintf("'%s' => %s\n",
-                $field, ArrayUtility::arrayExport(ArrayUtility::getValueByPath($phpArray, $field))
+                $fields[sizeof($fields)-1],
+                $this->fixIndentation(ArrayUtility::arrayExport($valueExport))
             );
         }
         return $code;
+    }
+
+    protected function fixIndentation($string): string
+    {
+        return str_replace('    ','   ',$string);
     }
 
     protected function write(string $path, string $code): void

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3CodeSnippets.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3CodeSnippets.php
@@ -15,6 +15,7 @@ namespace TYPO3\CMS\Screenshots\Runner\Codeception\Support\Helper;
 use Codeception\Module;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Screenshots\Util\ArrayHelper;
 
 /**
  * Helper to provide code snippets of TYPO3.
@@ -131,24 +132,12 @@ class Typo3CodeSnippets extends Module
         if ($field === '') {
             $code = ArrayUtility::arrayExport($phpArray);
         } else {
-            $fields = array_reverse(explode ( '/' , $field));
-            $valueExport = ArrayUtility::getValueByPath($phpArray, $field);
-            if (sizeof($fields) > 1) {
-                for ($i = 0; $i < sizeof($fields)-1; $i++) {
-                    $valueExport = [$fields[$i] => $valueExport];
-                }
-            }
+            $phpArray = ArrayHelper::getArrayByPath($phpArray, $field);
             $code = sprintf("'%s' => %s\n",
-                $fields[sizeof($fields)-1],
-                $this->fixIndentation(ArrayUtility::arrayExport($valueExport))
+                key($phpArray), ArrayUtility::arrayExport(current($phpArray))
             );
         }
         return $code;
-    }
-
-    protected function fixIndentation($string): string
-    {
-        return str_replace('    ','   ',$string);
     }
 
     protected function write(string $path, string $code): void

--- a/packages/screenshots/Classes/Util/ArrayHelper.php
+++ b/packages/screenshots/Classes/Util/ArrayHelper.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\CMS\Screenshots\Util;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+
+class ArrayHelper
+{
+    /**
+     * Extract field with path from array, e.g.
+     *
+     * Input:
+     *  [
+     *      'ctrl' => [],
+     *      'columns' => [
+     *          'title' => [
+     *              'label' => 'title',
+     *              'config' => []
+     *          ]
+     *      ]
+     *  ]
+     * Path: columns/title/label
+     * Output:
+     *  [
+     *      'columns' => [
+     *          'title' => [
+     *              'label' => 'title'
+     *          ]
+     *      ]
+     *  ]
+     *
+     * @param array $array
+     * @param string $path
+     * @return array
+     */
+    public static function getArrayByPath(array $array, string $path): array
+    {
+        $result = [];
+
+        $value = ArrayUtility::getValueByPath($array, $path);
+        $path = str_getcsv($path, '/');
+        $pathReverse = array_reverse($path);
+
+        for ($i=0; $i < count($pathReverse); $i++) {
+            if ($i === 0) {
+                $result = [$pathReverse[$i] => $value];
+            } else {
+                $result = [$pathReverse[$i] => $result];
+            }
+        }
+
+        return $result;
+    }
+}

--- a/packages/screenshots/Tests/Unit/Util/ArrayHelperTest.php
+++ b/packages/screenshots/Tests/Unit/Util/ArrayHelperTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\CMS\Screenshots\Tests\Unit\Util;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Screenshots\Util\ArrayHelper;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class ArrayHelperTest extends UnitTestCase
+{
+    /**
+     * @test
+     * @dataProvider getArrayByPathDataProvider
+     *
+     * @param array $array
+     * @param string $path
+     * @param array $expected
+     */
+    public function getArrayByPath(array $array, string $path, array $expected): void
+    {
+        self::assertEquals(ArrayHelper::getArrayByPath($array, $path), $expected);
+    }
+
+    public function getArrayByPathDataProvider(): array
+    {
+        $tca = [
+            'ctrl' => [],
+            'columns' => [
+                'title' => [
+                    'label' => 'title',
+                    'config' => [],
+                ],
+            ]
+        ];
+
+        return [
+            [
+                'array' => $tca,
+                'path' => 'ctrl',
+                'expected' => [
+                    'ctrl' => []
+                ]
+            ],
+            [
+                'array' => $tca,
+                'path' => 'columns/title/label',
+                'expected' => [
+                    'columns' => [
+                        'title' => [
+                            'label' => 'title'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Creating a code snippet for TCA field ['columns']['title']
results in

```
[
  'columns' =>
  [
    'title' => "Title"
  ]
]
```

Additionally reduce the indentation of code from 4 to 3 spaces
to align with the indentation of reST files for easy manual
editing.