### PR TITLE
[FEATURE] Support comments in screenshots.json

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -275,6 +275,25 @@ Actions can be nested to use the return value of the inner action by the outer, 
 which executes the action ``getUidByField()`` and uses the return value for parameter ``pid`` of action
 ``makeScreenshotOfTable()``.
 
+Comments can be inserted to facilitate maintenance work, e.g.
+
+.. code-block:: json
+
+   {
+      "suites": {
+         "Styleguide": {
+            "screenshots": [
+               [
+                  {"comment": "************************************"},
+                  {"comment": "Take screenshots of TYPO3 TCA table."},
+                  {"comment": "************************************"},
+                  {"action": "makeScreenshotOfTable", "pid": 27, "table": "pages", "fileName": "styleguide_root_page"}
+               ]
+            ]
+         }
+      }
+   }
+
 Available Actions
 -----------------
 

--- a/packages/screenshots/Classes/Configuration/Configuration.php
+++ b/packages/screenshots/Classes/Configuration/Configuration.php
@@ -121,6 +121,9 @@ class Configuration
                 'Styleguide' => [
                     'screenshots' => [
                         'actionsIdentifierScreenshots' => [
+                            ['comment' => '********************************************************'],
+                            ['comment' => 'Take screenshots configured in a dummy screenshots.json.'],
+                            ['comment' => '********************************************************'],
                             ['action' => 'resizeWindow', 'width' => 1024, 'height' => 768],
                             ['action' => 'setScreenshotsDocumentationPath', 'path' => "StyleguideDocumentation"],
                             ['action' => 'setScreenshotsImagePath', 'path' => "Images/StyleguideScreenshots"],
@@ -155,6 +158,12 @@ class Configuration
                             ['action' => 'setScreenshotsDefaultUid', 'uid' => 1],
                             ['action' => 'makeScreenshotOfTable', 'fileName' => 'tx_styleguide_elements_basic_of_pid_22'],
                             ['action' => 'makeScreenshotOfTable', 'pid' => '27', 'table' => 'tx_styleguide_elements_group', 'fileName' => 'tx_styleguide_elements_group_of_pid_27'],
+                            [
+                                'action' => 'makeScreenshotOfTable',
+                                'pid' => ['action' => 'getUidByField', 'table' => 'pages', 'field' => 'title', 'value' => 'elements group'],
+                                'table' => 'tx_styleguide_elements_group',
+                                'fileName' => 'tx_styleguide_elements_group_of_page_with_specific_title'
+                            ],
                             ['action' => 'makeScreenshotOfRecord', 'fileName' => 'tx_styleguide_elements_basic_with_uid_1'],
                             ['action' => 'makeScreenshotOfRecord', 'table' => 'tx_styleguide_elements_group', 'uid' => 3, 'fileName' => 'tx_styleguide_elements_group_with_uid_3'],
                             ['action' => 'makeScreenshotOfField', 'fields' => 'input_1', 'fileName' => 'tx_styleguide_elements_basic_with_uid_1_and_field_input_1'],


### PR DESCRIPTION
Comments can be inserted to facilitate maintenance work, e.g.
```
{
  "suites": {
     "Styleguide": {
        "screenshots": [
           [
              {"comment": "**********************************"},
              {"comment": "Resize browser window to 1024x768."},
              {"comment": "**********************************"},
              {"action": "resizeWindow", "width": 1024, "height": 768}
           ]
        ]
     }
  }
}
```
gives on CLI:
```
Scenario --
 ..
 **********************************
 Resize browser window to 1024x768.
 **********************************
 I resize window 1024,768
```