### PR TITLE
[BUGFIX] directive is called `code-block` not `code`

### DIFF
--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3CodeSnippets.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3CodeSnippets.php
@@ -147,7 +147,7 @@ class Typo3CodeSnippets extends Module
         $rst = <<<'NOWDOC'
 .. Automatic screenshot: Remove this line if you want to manually change this file
 
-.. code:: php
+.. code-block:: php
 
 %s
 NOWDOC;


### PR DESCRIPTION
solves #78 