### PR TITLE
[FEATURE] Add TYPO3 environment "Core" to run in plain TYPO3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,11 @@ Installation
 
       ddev launch
 
-3. Log into the TYPO3 backend and activate the page tree of ``EXT:styleguide`` or ``EXT:introduction``:
+3. Log into the TYPO3 backend
+4. Optionally activate the page tree of ``EXT:styleguide`` or ``EXT:introduction``:
 
-   -  add the page tree of ``EXT:introduction`` by de- and reactivating this extension - or -
-   -  add the page tree of ``EXT:styleguide`` by clicking in the upper right corner
+   -  initialize the page tree of ``EXT:introduction`` by de- and reactivating this extension - or -
+   -  initialize the page tree of ``EXT:styleguide`` by clicking in the upper right corner
       "(?)" -> "Styleguide" -> "TCA / Records" -> "Create styleguide page tree with data".
 
 Re-Installation
@@ -102,9 +103,9 @@ File ``screenshots.json``
 
 The runner configuration file ``screenshots.json`` must be placed in the root directory of the respective documentation
 folder, i.e. in ``public/t3docs/*/screenshots.json``. It defines in the first level the TYPO3 environment
-(e.g. "Styleguide", "Introduction", etc.) where the screenshots are taken, and in the second level it lists blocks of
-actions where each block ends with a captured screenshot. Each action is an object, where the key ``action`` marks the
-action name and the remaining keys represent the action parameters.
+(e.g. "Core", "Styleguide", "Introduction", etc.) where the screenshots are taken, and in the second level it lists
+blocks of actions where each block ends with a captured screenshot. Each action is an object, where the key ``action``
+marks the action name and the remaining keys represent the action parameters.
 
 Create a basic ``screenshots.json`` in an arbitrary manual folder at ``public/t3docs`` by
 
@@ -114,17 +115,21 @@ Create a basic ``screenshots.json`` in an arbitrary manual folder at ``public/t3
 
 where ``[folder]`` defaults to ``My-Manual`` if left blank.
 
-This is a small runner configuration which takes screenshots of two TYPO3 environments:
+This is a small runner configuration which takes screenshots of three TYPO3 environments:
 
 .. code-block:: json
 
    {
       "suites": {
-         "Introduction": {
+         "Core": {
             "screenshots": [
                [
-                  {"action": "makeScreenshotOfWindow", "fileName": "introduction_dashboard"}
-               ],
+                  {"action": "makeScreenshotOfWindow", "fileName": "core_dashboard"}
+               ]
+            ]
+         },
+         "Introduction": {
+            "screenshots": [
                [
                   {"action": "makeScreenshotOfFullPage", "fileName": "introduction_dashboard_full_page"}
                ]
@@ -316,6 +321,13 @@ Make all screenshots
 .. code-block:: bash
 
    ddev make-screenshots
+
+Make screenshots of TYPO3
+-------------------------
+
+.. code-block:: bash
+
+   ddev make-screenshots Core
 
 Make screenshots of TYPO3 + EXT:styleguide
 ------------------------------------------

--- a/packages/screenshots/Classes/Configuration/Configuration.php
+++ b/packages/screenshots/Classes/Configuration/Configuration.php
@@ -111,10 +111,23 @@ class Configuration
     {
         $this->config = [
             'suites' => [
+                'Core' => [
+                    'screenshots' => [
+                        [
+                            ['action' => 'resizeWindow', 'width' => 1024, 'height' => 768],
+                            ['action' => 'see', 'text' => "List"],
+                            ['action' => 'click', 'link' => "List"],
+                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => "typo3_dashboard_full_page"],
+                        ]
+                    ]
+                ],
                 'Introduction' => [
                     'screenshots' => [
                         [
-                            ['action' => 'makeScreenshotOfWindow', 'fileName' => "introduction_dashboard"],
+                            ['action' => 'resizeWindow', 'width' => 1024, 'height' => 768],
+                            ['action' => 'see', 'text' => "List"],
+                            ['action' => 'click', 'link' => "List"],
+                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => "introduction_dashboard_full_page"],
                         ]
                     ]
                 ],

--- a/packages/screenshots/Classes/Runner/Codeception/Core/CoreCest.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Core/CoreCest.php
@@ -1,7 +1,7 @@
 <?php
 
 declare(strict_types=1);
-namespace TYPO3\CMS\Screenshots\Runner\Codeception\Styleguide;
+namespace TYPO3\CMS\Screenshots\Runner\Codeception\Core;
 
 /*
  * This file is part of the TYPO3 project.
@@ -16,9 +16,9 @@ use TYPO3\CMS\Screenshots\Runner\Codeception\AbstractBaseCest;
 use TYPO3\CMS\Screenshots\Runner\Codeception\Support\Photographer;
 
 /**
- * Run all actions of TYPO3 environment "Styleguide"
+ * Run all actions of TYPO3 environment "Core"
  */
-class StyleguideCest extends AbstractBaseCest
+class CoreCest extends AbstractBaseCest
 {
     /**
      * @param Photographer $I
@@ -26,6 +26,6 @@ class StyleguideCest extends AbstractBaseCest
     public function makeScreenshots(Photographer $I): void
     {
         $I->useExistingSession('admin');
-        parent::runSuite($I, 'Styleguide');
+        parent::runSuite($I, 'Core');
     }
 }

--- a/packages/screenshots/Classes/Runner/Codeception/Introduction/IntroductionCest.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Introduction/IntroductionCest.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Screenshots\Runner\Codeception\AbstractBaseCest;
 use TYPO3\CMS\Screenshots\Runner\Codeception\Support\Photographer;
 
 /**
- * Tests the screenshots backend module can be loaded
+ * Run all actions of TYPO3 environment "Introduction"
  */
 class IntroductionCest extends AbstractBaseCest
 {

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Extension/CoreEnvironment.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Extension/CoreEnvironment.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\CMS\Screenshots\Runner\Codeception\Support\Extension;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Codeception\Event\SuiteEvent;
+use TYPO3\CMS\Core\Core\ApplicationContext;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extensionmanager\Utility\InstallUtility;
+use TYPO3\TestingFramework\Core\Acceptance\Extension\BackendEnvironment;
+
+/**
+ * Load all core extensions and call screenshots generator
+ */
+class CoreEnvironment extends BackendEnvironment
+{
+    /**
+     * Load all core extensions and EXT:screenshots
+     *
+     * @var array
+     */
+    protected $localConfig = [
+        // Order matters: Align sorting of core extensions with /public/typo3conf/PackageStates.php
+        'coreExtensionsToLoad' => [
+            'core',
+            'scheduler',
+            'extbase',
+            'fluid',
+            'frontend',
+            'fluid_styled_content',
+            'filelist',
+            'impexp',
+            'form',
+            'install',
+            'info',
+            'linkvalidator',
+            'reports',
+            'redirects',
+            'recordlist',
+            'backend',
+            'indexed_search',
+            'recycler',
+            'setup',
+            'rte_ckeditor',
+            'adminpanel',
+            'belog',
+            'beuser',
+            'dashboard',
+            'extensionmanager',
+            'felogin',
+            'filemetadata',
+            'lowlevel',
+            'opendocs',
+            'seo',
+            'sys_note',
+            't3editor',
+            'tstemplate',
+            'viewpage',
+        ],
+        'testExtensionsToLoad' => [
+            'typo3conf/ext/screenshots',
+        ],
+        'xmlDatabaseFixtures' => [
+            'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_users.xml',
+            'PACKAGE:typo3/testing-framework/Resources/Core/Acceptance/Fixtures/be_groups.xml',
+            'EXT:screenshots/Classes/Runner/Codeception/Fixtures/be_sessions.xml',
+        ],
+    ];
+
+    /**
+     * Generate screenshots data
+     *
+     * @param SuiteEvent $suiteEvent
+     */
+    public function bootstrapTypo3Environment(SuiteEvent $suiteEvent): void
+    {
+        parent::bootstrapTypo3Environment($suiteEvent);
+
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            Environment::isCli(),
+            Environment::isComposerMode(),
+            Environment::getProjectPath(),
+            Environment::getPublicPath(),
+            Environment::getVarPath(),
+            Environment::getConfigPath(),
+            Environment::getBackendPath() . '/index.php',
+            Environment::isWindows() ? 'WINDOWS' : 'UNIX'
+        );
+
+        // screenshots generator uses DataHandler for some parts. DataHandler needs an initialized BE user
+        // with admin right and the live workspace.
+        Bootstrap::initializeBackendUser();
+        $GLOBALS['BE_USER']->user['admin'] = 1;
+        $GLOBALS['BE_USER']->user['uid'] = 1;
+        $GLOBALS['BE_USER']->workspace = 0;
+        Bootstrap::initializeLanguageObject();
+    }
+}

--- a/packages/screenshots/Classes/Runner/codeception.yml
+++ b/packages/screenshots/Classes/Runner/codeception.yml
@@ -1,4 +1,9 @@
 suites:
+  Core:
+    actor: Photographer
+    extensions:
+      enabled:
+        - TYPO3\CMS\Screenshots\Runner\Codeception\Support\Extension\CoreEnvironment
   Introduction:
     actor: Photographer
     extensions:


### PR DESCRIPTION
A pure TYPO3 without any distribution package can provide screenshots of the original state of TYPO3 after installation.

Fixes: #62 