### PR TITLE
[FEATURE] Add TYPO3 suite "Examples"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,9 +114,9 @@ File ``screenshots.json``
 
 The runner configuration file ``screenshots.json`` must be placed in the root directory of the respective documentation
 folder, i.e. in ``public/t3docs/*/screenshots.json``. It defines in the first level the TYPO3 environment
-(e.g. "Core", "Styleguide", "Introduction", etc.) where the screenshots are taken, and in the second level it lists
-blocks of actions where each block ends with a captured screenshot. Each action is an object, where the key ``action``
-marks the action name and the remaining keys represent the action parameters.
+("Core", "Examples", "Introduction" or "Styleguide") where the screenshots are taken, and in the second level
+it lists blocks of actions where each block ends with a captured screenshot. Each action is an object, where the key
+``action`` marks the action name and the remaining keys represent the action parameters.
 
 Create a basic ``screenshots.json`` in an arbitrary manual folder at ``public/t3docs`` by
 
@@ -126,7 +126,7 @@ Create a basic ``screenshots.json`` in an arbitrary manual folder at ``public/t3
 
 where ``folder`` defaults to ``My-Manual`` if left blank.
 
-This is a small runner configuration which takes screenshots of three TYPO3 environments:
+This is a small runner configuration which takes screenshots of four TYPO3 environments:
 
 .. code-block:: json
 
@@ -136,6 +136,13 @@ This is a small runner configuration which takes screenshots of three TYPO3 envi
             "screenshots": [
                [
                   {"action": "makeScreenshotOfWindow", "fileName": "CoreDashboard"}
+               ]
+            ]
+         },
+         "Examples": {
+            "screenshots": [
+               [
+                  {"action": "makeScreenshotOfFullPage", "fileName": "ExamplesDashboardFullPage"}
                ]
             ]
          },
@@ -354,12 +361,12 @@ Make screenshots of TYPO3
 
    ddev make-screenshots -s Core
 
-Make screenshots of TYPO3 + EXT:styleguide
-------------------------------------------
+Make screenshots of TYPO3 + EXT:examples
+----------------------------------------
 
 .. code-block:: bash
 
-   ddev make-screenshots -s Styleguide
+   ddev make-screenshots -s Examples
 
 Make screenshots of TYPO3 + EXT:introduction
 --------------------------------------------
@@ -367,6 +374,13 @@ Make screenshots of TYPO3 + EXT:introduction
 .. code-block:: bash
 
    ddev make-screenshots -s Introduction
+
+Make screenshots of TYPO3 + EXT:styleguide
+------------------------------------------
+
+.. code-block:: bash
+
+   ddev make-screenshots -s Styleguide
 
 Make screenshots of TYPO3 + EXT:introduction + Subset of actions
 ----------------------------------------------------------------

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,15 @@
 	"repositories": [
 		{
 			"type": "vcs",
-			"url": "https://github.com/TYPO3-Documentation/introduction"
+			"url": "https://github.com/TYPO3-Documentation/bootstrap_package"
 		},
 		{
 			"type": "vcs",
-			"url": "https://github.com/TYPO3-Documentation/bootstrap_package"
+			"url": "https://github.com/TYPO3-Documentation/TYPO3CMS-Code-Examples"
+		},
+		{
+			"type": "vcs",
+			"url": "https://github.com/TYPO3-Documentation/introduction"
 		},
 		{
 			"type": "vcs",
@@ -71,6 +75,7 @@
 		"cweagans/composer-patches": "^1.7",
 		"helhum/typo3-console": "dev-latest",
 		"sensiolabs/ansi-to-html": "^1.2",
+		"t3docs/examples": "dev-master",
 		"typo3/cms-introduction": "dev-master",
 		"typo3/cms-styleguide": "dev-master",
 		"typo3/screenshots": "@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0aa07c8a10ada5eb8b54f949aec3b4e",
+    "content-hash": "baa1db4404e7f97e94d4a75b0f1aa91c",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -6608,6 +6608,58 @@
             "time": "2021-03-06T07:59:01+00:00"
         },
         {
+            "name": "t3docs/examples",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TYPO3-Documentation/TYPO3CMS-Code-Examples.git",
+                "reference": "4d1baf5f215311b384a51695625efdedb607eace"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TYPO3-Documentation/TYPO3CMS-Code-Examples/zipball/4d1baf5f215311b384a51695625efdedb607eace",
+                "reference": "4d1baf5f215311b384a51695625efdedb607eace",
+                "shasum": ""
+            },
+            "require": {
+                "typo3/cms-core": "^11.0.0",
+                "typo3/cms-fluid-styled-content": "^11.0.0"
+            },
+            "replace": {
+                "typo3-ter/examples": "self.version"
+            },
+            "default-branch": true,
+            "type": "typo3-cms-extension",
+            "extra": {
+                "typo3/cms": {
+                    "extension-key": "examples"
+                },
+                "branch-alias": {
+                    "dev-master": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "T3docs\\Examples\\": "Classes/"
+                }
+            },
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Documentation Team",
+                    "role": "Developer"
+                }
+            ],
+            "description": "This extension packages a number of code examples from the Core Documentation.",
+            "support": {
+                "source": "https://github.com/TYPO3-Documentation/TYPO3CMS-Code-Examples/tree/master",
+                "issues": "https://github.com/TYPO3-Documentation/TYPO3CMS-Code-Examples/issues"
+            },
+            "time": "2021-04-19T08:42:54+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.0",
             "source": {
@@ -9162,208 +9214,208 @@
     "packages-dev": [],
     "aliases": [
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-adminpanel",
             "version": "9999999-dev",
-            "package": "typo3/cms-adminpanel"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-backend",
             "version": "9999999-dev",
-            "package": "typo3/cms-backend"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-belog",
             "version": "9999999-dev",
-            "package": "typo3/cms-belog"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-beuser",
             "version": "9999999-dev",
-            "package": "typo3/cms-beuser"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-core",
             "version": "9999999-dev",
-            "package": "typo3/cms-core"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-dashboard",
             "version": "9999999-dev",
-            "package": "typo3/cms-dashboard"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-extbase",
             "version": "9999999-dev",
-            "package": "typo3/cms-extbase"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-extensionmanager",
             "version": "9999999-dev",
-            "package": "typo3/cms-extensionmanager"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-felogin",
             "version": "9999999-dev",
-            "package": "typo3/cms-felogin"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-filelist",
             "version": "9999999-dev",
-            "package": "typo3/cms-filelist"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-filemetadata",
             "version": "9999999-dev",
-            "package": "typo3/cms-filemetadata"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-fluid",
             "version": "9999999-dev",
-            "package": "typo3/cms-fluid"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-fluid-styled-content",
             "version": "9999999-dev",
-            "package": "typo3/cms-fluid-styled-content"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-form",
             "version": "9999999-dev",
-            "package": "typo3/cms-form"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-frontend",
             "version": "9999999-dev",
-            "package": "typo3/cms-frontend"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-impexp",
             "version": "9999999-dev",
-            "package": "typo3/cms-impexp"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-indexed-search",
             "version": "9999999-dev",
-            "package": "typo3/cms-indexed-search"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-info",
             "version": "9999999-dev",
-            "package": "typo3/cms-info"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-install",
             "version": "9999999-dev",
-            "package": "typo3/cms-install"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-linkvalidator",
             "version": "9999999-dev",
-            "package": "typo3/cms-linkvalidator"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-lowlevel",
             "version": "9999999-dev",
-            "package": "typo3/cms-lowlevel"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-opendocs",
             "version": "9999999-dev",
-            "package": "typo3/cms-opendocs"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-recordlist",
             "version": "9999999-dev",
-            "package": "typo3/cms-recordlist"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-recycler",
             "version": "9999999-dev",
-            "package": "typo3/cms-recycler"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-redirects",
             "version": "9999999-dev",
-            "package": "typo3/cms-redirects"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-reports",
             "version": "9999999-dev",
-            "package": "typo3/cms-reports"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-rte-ckeditor",
             "version": "9999999-dev",
-            "package": "typo3/cms-rte-ckeditor"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-scheduler",
             "version": "9999999-dev",
-            "package": "typo3/cms-scheduler"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-seo",
             "version": "9999999-dev",
-            "package": "typo3/cms-seo"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-setup",
             "version": "9999999-dev",
-            "package": "typo3/cms-setup"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-sys-note",
             "version": "9999999-dev",
-            "package": "typo3/cms-sys-note"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-t3editor",
             "version": "9999999-dev",
-            "package": "typo3/cms-t3editor"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-tstemplate",
             "version": "9999999-dev",
-            "package": "typo3/cms-tstemplate"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         },
         {
-            "alias": "11.1.2",
-            "alias_normalized": "11.1.2.0",
+            "package": "typo3/cms-viewpage",
             "version": "9999999-dev",
-            "package": "typo3/cms-viewpage"
+            "alias": "11.1.2",
+            "alias_normalized": "11.1.2.0"
         }
     ],
     "minimum-stability": "stable",
@@ -9404,6 +9456,7 @@
         "typo3/cms-viewpage": 20,
         "bk2k/bootstrap-package": 20,
         "helhum/typo3-console": 20,
+        "t3docs/examples": 20,
         "typo3/cms-introduction": 20,
         "typo3/cms-styleguide": 20,
         "typo3/screenshots": 20
@@ -9411,12 +9464,14 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
+        "ext-dom": "*",
         "ext-imagick": "*",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-libxml": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.4.1"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/packages/screenshots/Classes/Configuration/Configuration.php
+++ b/packages/screenshots/Classes/Configuration/Configuration.php
@@ -157,6 +157,16 @@ class Configuration
                         ]
                     ]
                 ],
+                'Examples' => [
+                    'screenshots' => [
+                        [
+                            ['action' => 'resizeWindow', 'width' => 1024, 'height' => 768],
+                            ['action' => 'see', 'text' => "List"],
+                            ['action' => 'click', 'link' => "List"],
+                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => "ExamplesDashboardFullPage"],
+                        ]
+                    ]
+                ],
                 'Introduction' => [
                     'screenshots' => [
                         [

--- a/packages/screenshots/Classes/Runner/Codeception/Examples/ExamplesCest.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Examples/ExamplesCest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\CMS\Screenshots\Runner\Codeception\Examples;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Screenshots\Runner\Codeception\AbstractBaseCest;
+use TYPO3\CMS\Screenshots\Runner\Codeception\Support\Photographer;
+
+/**
+ * Run all actions of TYPO3 environment "Examples"
+ */
+class ExamplesCest extends AbstractBaseCest
+{
+    /**
+     * @param Photographer $I
+     */
+    public function makeScreenshots(Photographer $I): void
+    {
+        parent::runSuite($I, 'Examples');
+    }
+}

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Extension/CoreEnvironment.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Extension/CoreEnvironment.php
@@ -97,13 +97,5 @@ class CoreEnvironment extends BackendEnvironment
             Environment::getBackendPath() . '/index.php',
             Environment::isWindows() ? 'WINDOWS' : 'UNIX'
         );
-
-        // screenshots generator uses DataHandler for some parts. DataHandler needs an initialized BE user
-        // with admin right and the live workspace.
-        Bootstrap::initializeBackendUser();
-        $GLOBALS['BE_USER']->user['admin'] = 1;
-        $GLOBALS['BE_USER']->user['uid'] = 1;
-        $GLOBALS['BE_USER']->workspace = 0;
-        Bootstrap::initializeLanguageObject();
     }
 }

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Extension/CoreEnvironment.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Extension/CoreEnvironment.php
@@ -22,13 +22,11 @@ use TYPO3\CMS\Extensionmanager\Utility\InstallUtility;
 use TYPO3\TestingFramework\Core\Acceptance\Extension\BackendEnvironment;
 
 /**
- * Load all core extensions and call screenshots generator
+ * Load all core extensions and EXT:screenshots
  */
 class CoreEnvironment extends BackendEnvironment
 {
     /**
-     * Load all core extensions and EXT:screenshots
-     *
      * @var array
      */
     protected $localConfig = [
@@ -80,7 +78,7 @@ class CoreEnvironment extends BackendEnvironment
     ];
 
     /**
-     * Generate screenshots data
+     * Initialize TYPO3 instance
      *
      * @param SuiteEvent $suiteEvent
      */

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Extension/ExamplesEnvironment.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Extension/ExamplesEnvironment.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\CMS\Screenshots\Runner\Codeception\Support\Extension;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Codeception\Event\SuiteEvent;
+use TYPO3\CMS\Core\Core\ApplicationContext;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extensionmanager\Utility\InstallUtility;
+use TYPO3\TestingFramework\Core\Acceptance\Extension\BackendEnvironment;
+
+/**
+ * Load all core extensions and EXT:examples and EXT:screenshots
+ */
+class ExamplesEnvironment extends BackendEnvironment
+{
+    /**
+     * @var array
+     */
+    protected $localConfig = [
+        // Order matters: Align sorting of core extensions with /public/typo3conf/PackageStates.php
+        'coreExtensionsToLoad' => [
+            'core',
+            'scheduler',
+            'extbase',
+            'fluid',
+            'frontend',
+            'fluid_styled_content',
+            'filelist',
+            'impexp',
+            'form',
+            'install',
+            'info',
+            'linkvalidator',
+            'reports',
+            'redirects',
+            'recordlist',
+            'backend',
+            'indexed_search',
+            'recycler',
+            'setup',
+            'rte_ckeditor',
+            'adminpanel',
+            'belog',
+            'beuser',
+            'dashboard',
+            'extensionmanager',
+            'felogin',
+            'filemetadata',
+            'lowlevel',
+            'opendocs',
+            'seo',
+            'sys_note',
+            't3editor',
+            'tstemplate',
+            'viewpage',
+        ],
+        'testExtensionsToLoad' => [
+            'typo3conf/ext/examples',
+            'typo3conf/ext/screenshots',
+        ],
+        'xmlDatabaseFixtures' => [
+            'EXT:screenshots/Classes/Runner/Codeception/Fixtures/StyleguideEnvironment/be_groups.xml',
+            'EXT:screenshots/Classes/Runner/Codeception/Fixtures/StyleguideEnvironment/be_sessions.xml',
+            'EXT:screenshots/Classes/Runner/Codeception/Fixtures/StyleguideEnvironment/be_users.xml',
+        ],
+    ];
+
+    /**
+     * Initialize TYPO3 instance
+     *
+     * @param SuiteEvent $suiteEvent
+     */
+    public function bootstrapTypo3Environment(SuiteEvent $suiteEvent): void
+    {
+        parent::bootstrapTypo3Environment($suiteEvent);
+
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            Environment::isCli(),
+            Environment::isComposerMode(),
+            Environment::getProjectPath(),
+            Environment::getPublicPath(),
+            Environment::getVarPath(),
+            Environment::getConfigPath(),
+            Environment::getBackendPath() . '/index.php',
+            Environment::isWindows() ? 'WINDOWS' : 'UNIX'
+        );
+    }
+}

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Extension/IntroductionEnvironment.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Extension/IntroductionEnvironment.php
@@ -22,13 +22,11 @@ use TYPO3\CMS\Extensionmanager\Utility\InstallUtility;
 use TYPO3\TestingFramework\Core\Acceptance\Extension\BackendEnvironment;
 
 /**
- * Load various core extensions and introduction package and call screenshots generator
+ * Load all core extensions and EXT:introduction and EXT:bootstrap_package and EXT:screenshots
  */
 class IntroductionEnvironment extends BackendEnvironment
 {
     /**
-     * Load all core extensions, the introduction package and EXT:screenshots
-     *
      * @var array
      */
     protected $localConfig = [
@@ -81,7 +79,7 @@ class IntroductionEnvironment extends BackendEnvironment
     ];
 
     /**
-     * Generate screenshots data
+     * Initialize TYPO3 instance
      *
      * @param SuiteEvent $suiteEvent
      */

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Extension/IntroductionEnvironment.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Extension/IntroductionEnvironment.php
@@ -99,7 +99,7 @@ class IntroductionEnvironment extends BackendEnvironment
             Environment::isWindows() ? 'WINDOWS' : 'UNIX'
         );
 
-        // screenshots generator uses DataHandler for some parts. DataHandler needs an initialized BE user
+        // The database initialization uses DataHandler for some parts. DataHandler needs an initialized BE user
         // with admin right and the live workspace.
         Bootstrap::initializeBackendUser();
         $GLOBALS['BE_USER']->user['admin'] = 1;

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Extension/StyleguideEnvironment.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Extension/StyleguideEnvironment.php
@@ -20,13 +20,11 @@ use TYPO3\CMS\Styleguide\TcaDataGenerator\Generator;
 use TYPO3\TestingFramework\Core\Acceptance\Extension\BackendEnvironment;
 
 /**
- * Load various core extensions and screenshots and call screenshots generator
+ * Load all core extensions and EXT:styleguide and EXT:screenshots
  */
 class StyleguideEnvironment extends BackendEnvironment
 {
     /**
-     * Load all core extensions, the styleguide package and EXT:screenshots
-     *
      * @var array
      */
     protected $localConfig = [
@@ -79,7 +77,7 @@ class StyleguideEnvironment extends BackendEnvironment
     ];
 
     /**
-     * Generate styleguide data
+     * Initialize TYPO3 instance
      *
      * @param SuiteEvent $suiteEvent
      */

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Extension/StyleguideEnvironment.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Extension/StyleguideEnvironment.php
@@ -97,7 +97,7 @@ class StyleguideEnvironment extends BackendEnvironment
             Environment::isWindows() ? 'WINDOWS' : 'UNIX'
         );
 
-        // styleguide generator uses DataHandler for some parts. DataHandler needs an initialized BE user
+        // The database initialization uses DataHandler for some parts. DataHandler needs an initialized BE user
         // with admin right and the live workspace.
         Bootstrap::initializeBackendUser();
         $GLOBALS['BE_USER']->user['admin'] = 1;

--- a/packages/screenshots/Classes/Runner/codeception.yml
+++ b/packages/screenshots/Classes/Runner/codeception.yml
@@ -11,6 +11,18 @@ suites:
     extensions:
       enabled:
         - TYPO3\CMS\Screenshots\Runner\Codeception\Support\Extension\CoreEnvironment
+  Examples:
+    actor: Photographer
+    modules:
+      enabled:
+        - TYPO3\CMS\Screenshots\Runner\Codeception\Support\Helper\Typo3Login:
+            sessions:
+              # This sessions must exist in the database fixture to get a logged in state.
+              admin: 886526ce72b86870739cc41991144ec1
+              editor: ff83dfd81e20b34c27d3e97771a4525a
+    extensions:
+      enabled:
+        - TYPO3\CMS\Screenshots\Runner\Codeception\Support\Extension\ExamplesEnvironment
   Introduction:
     actor: Photographer
     modules:

--- a/packages/screenshots/Resources/Private/Templates/ScreenshotsManager/Make.html
+++ b/packages/screenshots/Resources/Private/Templates/ScreenshotsManager/Make.html
@@ -24,7 +24,7 @@
                 <f:form.select
                     id="screenshotsSuite"
                     name="suiteFilter"
-                    options="{Core: 'Core (TYPO3)', Introduction: 'Introduction (TYPO3 + EXT:introduction)', Styleguide: 'Styleguide (TYPO3 + EXT:styleguide)'}"
+                    options="{Core: 'Core (TYPO3)', Examples: 'Examples (TYPO3 + EXT:examples)', Introduction: 'Introduction (TYPO3 + EXT:introduction)', Styleguide: 'Styleguide (TYPO3 + EXT:styleguide)'}"
                     prependOptionLabel="All"
                     prependOptionValue=""
                     value="{suiteFilter}"


### PR DESCRIPTION
Add a TYPO3 + `EXT:examples` environment which can provide screenshots of a TYPO3 Documentation Team owned extension.

![ExamplesDashboardFullPage](https://user-images.githubusercontent.com/20297232/119981492-faa87400-bfbd-11eb-8fc9-6e5bf8d9944f.png)