### PR TITLE
[FEATURE] Support inclusion of actions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -335,6 +335,34 @@ Comments can be inserted to facilitate maintenance work, e.g.
       }
    }
 
+An action block can be included in another action block of the same suite by assigning a custom identifier to the former
+and using that identifier in the latter with the ``include`` directive, e.g.
+
+.. code-block:: json
+
+   {
+      "suites": {
+         "Styleguide": {
+            "screenshots": {
+               "_default": [
+                  {"action": "resizeWindow", "width": 1024, "height": 768}
+               ],
+               "list": [
+                  {"include": "_default"},
+                  {"action": "see", "text": "List"},
+               ]
+            }
+         }
+      }
+   }
+
+where the actions with ID "_default" are included and executed at the beginning of the action block with ID "list".
+
+Action blocks will not be executed directly if their custom identifier starts with an underscore. Therefore it is useful
+to use such underscore identifiers for action blocks that are intended for inclusion only.
+
+Included blocks can themselves include other blocks.
+
 Available actions
 -----------------
 
@@ -435,7 +463,9 @@ Make screenshots of TYPO3 + EXT:styleguide
 Make screenshots of TYPO3 + EXT:introduction + Subset of actions
 ----------------------------------------------------------------
 
-A custom identifier can be assigned to a block of actions and then used to execute only that specific subset of actions.
+A custom identifier can be assigned to an action block and then used to execute only that specific subset of actions.
+However, action blocks cannot be executed if their custom identifier begins with an underscore, which is intended for
+inclusion in other action blocks.
 
 .. code-block:: json
 

--- a/packages/screenshots/Classes/Controller/ScreenshotsManagerController.php
+++ b/packages/screenshots/Classes/Controller/ScreenshotsManagerController.php
@@ -76,7 +76,7 @@ class ScreenshotsManagerController extends ActionController
         $actionsIds = [];
         foreach ($configurations as &$configuration) {
             $configuration->read();
-            foreach ($configuration->getActionsIds() as $actionsId) {
+            foreach ($configuration->getSelectableActionsIds() as $actionsId) {
                 if (!isset($actionsIds[$actionsId])) {
                     $actionsIds[$actionsId] = $actionsId;
                 }

--- a/packages/screenshots/Classes/Runner/Codeception/AbstractBaseCest.php
+++ b/packages/screenshots/Classes/Runner/Codeception/AbstractBaseCest.php
@@ -75,7 +75,7 @@ abstract class AbstractBaseCest
             $I->setScreenshotsBasePath($actualDirectory);
 
             $configuration->read();
-            $config = $configuration->getConfig();
+            $config = $configuration->getConfigPrepared();
             if (!empty($config['suites'][$suite]['screenshots'])) {
                 foreach ($config['suites'][$suite]['screenshots'] as $actionsId => $actions) {
                     $isActionsEnabled = empty($actionsIdFilter) || $actionsId === $actionsIdFilter;

--- a/packages/screenshots/Tests/Unit/Configuration/ConfigurationTest.php
+++ b/packages/screenshots/Tests/Unit/Configuration/ConfigurationTest.php
@@ -79,6 +79,49 @@ class ConfigurationTest extends UnitTestCase
     /**
      * @test
      */
+    public function prepareConfigResolvesIncludesAndRemovesNotExecutableActionsIds(): void
+    {
+        $config = [
+            'suites' => [
+                'Introduction' => [
+                    'screenshots' => [
+                        '_include_1' => [
+                            ['action' => 'makeScreenshotOfWindow', 'fileName' => "introduction_dashboard_1"]
+                        ],
+                        '_include_2' => [
+                            ['include' => '_include_1'],
+                            ['action' => 'makeScreenshotOfWindow', 'fileName' => "introduction_dashboard_2"]
+                        ],
+                        'run' => [
+                            ['include' => '_include_2']
+                        ]
+                    ]
+                ]
+            ]
+        ];
+        $expected = [
+            'suites' => [
+                'Introduction' => [
+                    'screenshots' => [
+                        'run' => [
+                            ['action' => 'makeScreenshotOfWindow', 'fileName' => "introduction_dashboard_1"],
+                            ['action' => 'makeScreenshotOfWindow', 'fileName' => "introduction_dashboard_2"]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $configuration = new Configuration();
+        $configuration->setConfig($config);
+
+        self::assertEquals($config, $configuration->getConfig());
+        self::assertEquals($expected, $configuration->getConfigPrepared());
+    }
+
+    /**
+     * @test
+     */
     public function isExistingAdaptsAfterWritingTheConfiguration(): void
     {
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['folderCreateMask'] = '0770';
@@ -96,11 +139,11 @@ class ConfigurationTest extends UnitTestCase
     /**
      * @test
      */
-    public function getActionsIds(): void
+    public function getSelectableActionsIds(): void
     {
         $configuration = new Configuration('DummyPath');
         $configuration->createBasicConfig();
-        $actualActionsIds = $configuration->getActionsIds();
+        $actualActionsIds = $configuration->getSelectableActionsIds();
         $expectedActionsIds = [
             'actionsIdentifierUserSwitch',
             'actionsIdentifierScreenshots',


### PR DESCRIPTION
An action block can be included in another action block of the same suite by assigning a custom identifier to the former
and using that identifier in the latter with the ``include`` directive, e.g.

```
{
    "suites": {
        "Styleguide": {
            "screenshots": {
                "_default": [
                    {"action": "resizeWindow", "width": 1024, "height": 768}
                ],
                "list": [
                    {"include": "_default"},
                    {"action": "see", "text": "List"},
                ]
            }
        }
    }
}
```

Action blocks will not be executed directly if their custom identifier starts with an underscore. Therefore it is useful
to use such underscore identifiers for action blocks that are intended for inclusion only.

Depends on: PR #133 and PR #136 
Fixes: #122 