### PR TITLE
[FEATURE] Support creation of JSON code snippets 

### DIFF
--- a/.ddev/commands/web/make-screenshots
+++ b/.ddev/commands/web/make-screenshots
@@ -74,19 +74,34 @@ make_screenshots() {
 }
 
 fetch_suites() {
-    echo $(typo3 screenshots:fetchsuites --target-path=$TARGET_PATH --suite-id=$SUITE_ID --actions-id=$ACTIONS_ID)
+    local suites;
+    local exitStatus;
+
+    suites=$(typo3 screenshots:fetchsuites --target-path=$TARGET_PATH --suite-id=$SUITE_ID --actions-id=$ACTIONS_ID)
+    exitStatus=$?
+
+    echo $suites
+    exit $exitStatus
 }
 
 run_suites() {
+    local suites;
+    local exitStatus;
+
     suites=$(fetch_suites)
+    exitStatus=$?
 
-    if [ "$suites" != "[]" ]; then
-        while read suite; do
-            path=$(jq -r '.path' <<< "$suite")
-            suiteId=$(jq -r '.suiteId' <<< "$suite")
+    if [ "$exitStatus" -eq 0 ]; then
+        if [ "$suites" != "[]" ]; then
+            while read suite; do
+                path=$(jq -r '.path' <<< "$suite")
+                suiteId=$(jq -r '.suiteId' <<< "$suite")
 
-            TARGET_PATH="$path" SUITE_ID="$suiteId" make_screenshots
-        done <<< $(jq -c '.[]' <<< "$suites")
+                TARGET_PATH="$path" SUITE_ID="$suiteId" make_screenshots
+            done <<< $(jq -c '.[]' <<< "$suites")
+        fi
+    else
+        echo $suites
     fi
 }
 

--- a/README.rst
+++ b/README.rst
@@ -273,8 +273,9 @@ and can be used to include the screenshot comfortably into a documentation. The 
 Another redundant documentation job besides taking screenshots is to insert and update code snippets. With action
 ``createCodeSnippet`` a specific TYPO3 code source file gets transformed into a reStructuredText file for inclusion and
 gets saved to folder ``Documentation/CodeSnippets``. The folder can be changed by ``setCodeSnippetsTargetPath``.
-Furthermore there are dedicated actions like ``createPhpArrayCodeSnippet``, ``createPhpClassCodeSnippet``,
-``createXmlCodeSnippet`` or ``createYamlCodeSnippet`` to store only excerpts of code files.
+Furthermore there are dedicated actions like ``createJsonCodeSnippet``, ``createPhpArrayCodeSnippet``,
+``createPhpClassCodeSnippet``, ``createXmlCodeSnippet`` or ``createYamlCodeSnippet`` to store only excerpts of code
+files.
 
 .. code-block:: json
 
@@ -295,6 +296,7 @@ Furthermore there are dedicated actions like ``createPhpArrayCodeSnippet``, ``cr
                      "lineStartNumber": 1,
                      "emphasizeLines": [5,6,7]
                   }
+                  {"action": "createJsonCodeSnippet", "sourceFile": "typo3/sysext/core/composer.json", "fields": ["name", "support/source"], "targetFileName": "CoreComposerJsonDescription"},
                   {"action": "createPhpArrayCodeSnippet", "sourceFile": "typo3/sysext/core/Configuration/TCA/be_groups.php", "fields": ["types"], "targetFileName": "CoreBeGroupsTypes"},
                   {"action": "createPhpClassCodeSnippet", "class": "TYPO3\\CMS\\Core\\Cache\\Backend\\FileBackend", "members": ["frozen", "freeze"], "withComment": true, "targetFileName": "FileBackendFreezeWithComments"},
                   {"action": "createXmlCodeSnippet", "sourceFile": "typo3/sysext/form/Configuration/FlexForms/FormFramework.xml", "nodes": ["T3DataStructure/sheets/sDEF"], "targetFileName": "FormFrameworkXmlSheetSDef"},

--- a/packages/screenshots/Classes/Command/FetchSuitesCommand.php
+++ b/packages/screenshots/Classes/Command/FetchSuitesCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Screenshots\Configuration\ConfigurationRepository;
 use TYPO3\CMS\Screenshots\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Screenshots\Util\JsonHelper;
 
 /**
  * Command for fetching executable suites by filter
@@ -96,7 +97,7 @@ class FetchSuitesCommand extends Command
                     }
                 }
             }
-            $io->text(json_encode($suites, JSON_PRETTY_PRINT));
+            $io->text(JsonHelper::printPrettyJson($suites));
             return 0;
         } catch (\Exception $e) {
             $io->error(sprintf('%s: %s', $e->getCode(), $e->getMessage()));

--- a/packages/screenshots/Classes/Command/MappingsCommand.php
+++ b/packages/screenshots/Classes/Command/MappingsCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Screenshots\Util\JsonHelper;
 
 /**
  * Command for listing all mappings from one field to another field of a specific database table.
@@ -82,7 +83,7 @@ class MappingsCommand extends Command
                     $mappings[$row[$fromField]] = $row[$toField];
                 }
             }
-            $io->text(json_encode($mappings, JSON_PRETTY_PRINT));
+            $io->text(JsonHelper::printPrettyJson($mappings));
             return 0;
         } catch (\Exception $e) {
             $io->error(sprintf('%s: %s', $e->getCode(), $e->getMessage()));

--- a/packages/screenshots/Classes/Configuration/Configuration.php
+++ b/packages/screenshots/Classes/Configuration/Configuration.php
@@ -406,6 +406,8 @@ class Configuration
                             ],
                             ['action' => 'setCodeSnippetsSourcePath', 'path' => "typo3/sysext/core"],
                             ['action' => 'createCodeSnippet', 'sourceFile' => 'Configuration/TCA/be_groups.php', 'targetFileName' => 'BeGroupsWithPresetSourcePath'],
+                            ['action' => 'createJsonCodeSnippet', 'sourceFile' => 'composer.json', 'targetFileName' => 'CoreComposerJson'],
+                            ['action' => 'createJsonCodeSnippet', 'sourceFile' => 'composer.json', 'fields' => ["name", "support/source"], 'inlineLevel' => 1, 'targetFileName' => 'CoreComposerJsonDescription'],
                             ['action' => 'createPhpArrayCodeSnippet', 'sourceFile' => 'Configuration/TCA/be_groups.php', 'targetFileName' => 'TcaBeGroups'],
                             ['action' => 'createPhpArrayCodeSnippet', 'sourceFile' => 'Configuration/TCA/be_groups.php', 'fields' => ['columns/title'], 'targetFileName' => 'TcaBeGroupsColumnsTitle'],
                             ['action' => 'createPhpClassCodeSnippet', 'class' => 'TYPO3\CMS\Core\Cache\Backend\FileBackend', 'members' => ['setCache', 'frozen', 'freeze'], 'targetFileName' => 'FileBackendFreeze'],

--- a/packages/screenshots/Classes/Runner/Codeception/AbstractBaseCest.php
+++ b/packages/screenshots/Classes/Runner/Codeception/AbstractBaseCest.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Screenshots\Configuration\ConfigurationRepository;
 use TYPO3\CMS\Screenshots\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Screenshots\Runner\Codeception\Support\Photographer;
 use TYPO3\CMS\Screenshots\Util\FileHelper;
+use TYPO3\CMS\Screenshots\Util\JsonHelper;
 
 /**
  * Tests the screenshots backend module can be loaded
@@ -87,7 +88,8 @@ abstract class AbstractBaseCest
             $this->runAction($I, $action);
         } else {
             throw new ConfigurationException(sprintf(
-                'Parameter "action" or "comment" is missing in configuration "%s".', json_encode($action)
+                'Parameter "action" or "comment" is missing in configuration "%s".',
+                JsonHelper::printInlineJson($action)
             ));
         }
     }

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Draw.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Draw.php
@@ -14,6 +14,7 @@ namespace TYPO3\CMS\Screenshots\Runner\Codeception\Support\Helper;
 
 use Codeception\Module;
 use Codeception\Module\WebDriver;
+use TYPO3\CMS\Screenshots\Util\JsonHelper;
 
 /**
  * Helper to highlight DOM elements for screenshots.
@@ -87,7 +88,7 @@ for (let i = 0; i < elements.length; i++) {
 NOWDOC;
 
         $this->getWebDriver()->executeJS(
-            sprintf($js, json_encode($this->paneCss), json_encode($boxCss)),
+            sprintf($js, JsonHelper::printInlineJson($this->paneCss), JsonHelper::printInlineJson($boxCss)),
             $elements
         );
     }
@@ -169,7 +170,15 @@ for (let i = 0; i < elements.length; i++) {
 NOWDOC;
 
         $this->getWebDriver()->executeJS(
-            sprintf($js, json_encode($this->paneCss), json_encode($arrowCss), $arrowSvgOneLine, $positionX, $positionY, $position),
+            sprintf(
+                $js,
+                JsonHelper::printInlineJson($this->paneCss),
+                JsonHelper::printInlineJson($arrowCss),
+                $arrowSvgOneLine,
+                $positionX,
+                $positionY,
+                $position
+            ),
             $elements
         );
     }
@@ -252,7 +261,13 @@ for (let i = 0; i < elements.length; i++) {
 NOWDOC;
 
         $this->getWebDriver()->executeJS(
-            sprintf($js, json_encode($this->paneCss), $position, $label, json_encode($badgeCss)),
+            sprintf(
+                $js,
+                JsonHelper::printInlineJson($this->paneCss),
+                $position,
+                $label,
+                JsonHelper::printInlineJson($badgeCss)
+            ),
             $elements
         );
     }

--- a/packages/screenshots/Classes/Util/JsonHelper.php
+++ b/packages/screenshots/Classes/Util/JsonHelper.php
@@ -39,12 +39,17 @@ class JsonHelper
      */
     public static function extractFieldsFromJson(string $json, array $fields, int $inlineLevel = 99): string
     {
-        $arrayIn = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        $arrayIn = self::parseArrayFromJson($json);
         $arrayOut = ArrayHelper::extractFieldsFromArray($arrayIn, $fields);
         return self::printJson($arrayOut, $inlineLevel);
     }
 
-    protected static function printJson(array $jsonArray, int $inlineLevel = 99): string
+    public static function parseArrayFromJson(string $json): array
+    {
+        return json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    public static function printJson(array $jsonArray, int $inlineLevel = 99): string
     {
         $inlineJsons = [];
 
@@ -86,5 +91,15 @@ class JsonHelper
     protected static function addWhitespaceToInlineJson(string $inlineJsons): string
     {
         return preg_replace(["#([0-9\"'}\]],)(\S)#", "#([\"']:)(\S)#"], "\\1 \\2", $inlineJsons);
+    }
+
+    public static function printPrettyJson(array $jsonArray): string
+    {
+        return self::printJson($jsonArray, 99);
+    }
+
+    public static function printInlineJson(array $jsonArray): string
+    {
+        return self::printJson($jsonArray, 0);
     }
 }

--- a/packages/screenshots/Classes/Util/JsonHelper.php
+++ b/packages/screenshots/Classes/Util/JsonHelper.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\CMS\Screenshots\Util;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+class JsonHelper
+{
+    /**
+     * Extract fields from JSON, e.g.
+     *
+     * Input:
+     * {
+     *      "scalar": "value",
+     *      "array": ["value1", "value2"],
+     *      "object": {"key1": "value1", "key2": "value2"}
+     * }
+     *
+     * Fields: ["array", "object/key2"]
+     *
+     * Output:
+     * {
+     *      "array": ["value1", "value2"],
+     *      "object": {"key2": "value2"}
+     * }
+     *
+     * @param string $json
+     * @param array $fields
+     * @param int $inlineLevel The level where you switch to inline JSON
+     * @return string
+     */
+    public static function extractFieldsFromJson(string $json, array $fields, int $inlineLevel = 99): string
+    {
+        $arrayIn = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        $arrayOut = ArrayHelper::extractFieldsFromArray($arrayIn, $fields);
+        return self::printJson($arrayOut, $inlineLevel);
+    }
+
+    protected static function printJson(array $jsonArray, int $inlineLevel = 99): string
+    {
+        $inlineJsons = [];
+
+        self::grabInlineJsonsAndReplaceWithPlaceholders($jsonArray, $inlineLevel, $inlineJsons);
+
+        $json = json_encode($jsonArray, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+        $json = str_replace(array_keys($inlineJsons), array_values($inlineJsons), $json);
+        return $json;
+    }
+
+    protected static function grabInlineJsonsAndReplaceWithPlaceholders(
+        &$jsonEntry,
+        int $inlineLevel,
+        array &$inlineJsons,
+        array $keys = []
+    ): void {
+        if (!is_array($jsonEntry)) {
+            return;
+        }
+
+        if ($inlineLevel > 0) {
+            foreach ($jsonEntry as $key => &$child) {
+                self::grabInlineJsonsAndReplaceWithPlaceholders(
+                    $child,
+                    $inlineLevel-1,
+                    $inlineJsons,
+                    array_merge($keys, [$key])
+                );
+            }
+        } else {
+            $placeholder = md5(implode('_', $keys));
+            $inlineJson = json_encode($jsonEntry, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+            $inlineJson = self::addWhitespaceToInlineJson($inlineJson);
+            $inlineJsons["\"$placeholder\""] = $inlineJson;
+            $jsonEntry = $placeholder;
+        }
+    }
+
+    protected static function addWhitespaceToInlineJson(string $inlineJsons): string
+    {
+        return preg_replace(["#([0-9\"'}\]],)(\S)#", "#([\"']:)(\S)#"], "\\1 \\2", $inlineJsons);
+    }
+}

--- a/packages/screenshots/Tests/Unit/Command/FetchSuitesCommandTest.php
+++ b/packages/screenshots/Tests/Unit/Command/FetchSuitesCommandTest.php
@@ -25,7 +25,7 @@ class FetchSuitesCommandTest extends UnitTestCase
     /**
      * @test
      */
-    public function exportCommandReturnsProperJson(): void
+    public function fetchSuitesCommandReturnsProperJson(): void
     {
         $vfsPath = vfsStream::setup('public')->url();
 
@@ -46,6 +46,25 @@ class FetchSuitesCommandTest extends UnitTestCase
                 ['path' => $vfsPath, 'suiteId' => 'Styleguide'],
             ],
             json_decode($tester->getDisplay(), true)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function fetchSuitesCommandDisplaysExceptionIfJsonIsMalformed(): void
+    {
+        $vfsPath = vfsStream::setup('public')->url();
+
+        file_put_contents($vfsPath . '/screenshots.json', "{'i-am-a': 'malformed-json',}");
+
+        $tester = new CommandTester(new FetchSuitesCommand());
+        $tester->execute(['--target-path' => $vfsPath], []);
+
+        self::assertEquals(1, $tester->getStatusCode());
+        self::assertEquals(
+            '[ERROR] 4: Syntax error in vfs://public/screenshots.json',
+            trim($tester->getDisplay())
         );
     }
 }

--- a/packages/screenshots/Tests/Unit/Fixtures/Json.json
+++ b/packages/screenshots/Tests/Unit/Fixtures/Json.json
@@ -1,0 +1,25 @@
+{
+	"string": "value",
+	"number": 1.0,
+	"array": [
+		"value-2",
+		2.0,
+		{
+			"string": "value-2-1",
+			"number": 2.1
+		}
+	],
+	"object": {
+		"string": "value-3",
+		"number": 3.0,
+		"array": [
+			"value-3-1",
+			3.1,
+			{
+				"string": "value-3-2-1: value-3-2-2, value-3-2-3",
+				"number": 3.2
+			},
+			"value-3-3"
+		]
+	}
+}

--- a/packages/screenshots/Tests/Unit/Runner/Codeception/Support/Helper/Typo3CliTest.php
+++ b/packages/screenshots/Tests/Unit/Runner/Codeception/Support/Helper/Typo3CliTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\CMS\Screenshots\Tests\Unit\Runner\Codeception\Support\Helper;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Codeception\Lib\ModuleContainer;
+use TYPO3\CMS\Screenshots\Runner\Codeception\Support\Helper\Typo3Cli;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class Typo3CliTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function getUidByField(): void
+    {
+        $typo3Cli = $this->getTypo3CliMock();
+        $typo3Cli->expects(self::once())->method('fetchMappings')->willReturn([
+            0,
+            explode("\n", json_encode([
+                "0" => 1,
+                "1" => 2,
+                "6" => 7,
+                "7" => 8,
+            ], JSON_PRETTY_PRINT))
+        ]);
+        $uid = $typo3Cli->getUidByField('pages', 'pid', 1);
+
+        self::assertEquals(2, $uid);
+    }
+
+    /**
+     * @test
+     */
+    public function getUidByFieldThrowsExceptionIfMappingsJsonIsMalformed(): void
+    {
+        $typo3Cli = $this->getTypo3CliMock();
+        $typo3Cli->expects(self::once())->method('fetchMappings')->willReturn([
+            0,
+            explode("\n", json_encode([
+                "0" => 1,
+                "1" => 2,
+                "6" => 7,
+                "7" => 8,
+            ], JSON_PRETTY_PRINT) . ',')
+        ]);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('JSON Error #4: Syntax error');
+
+        $typo3Cli->getUidByField('pages', 'pid', 1);
+    }
+
+    /**
+     * @test
+     */
+    public function getUidByFieldThrowsExceptionIfFetchingOfMappingsFails(): void
+    {
+        $typo3Cli = $this->getTypo3CliMock();
+        $typo3Cli->expects(self::once())->method('fetchMappings')->willReturn([1, ['Failed']]);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('TYPO3 Cli Error #1: Failed');
+
+        $typo3Cli->getUidByField('pages', 'pid', 1);
+    }
+
+    protected function getTypo3CliMock(): Typo3Cli
+    {
+        $typo3Cli = $this->getMockBuilder(Typo3Cli::class)
+            ->setConstructorArgs([$this->getModuleContainerStub()])
+            ->onlyMethods(['fetchMappings'])
+            ->getMock();
+
+        return $typo3Cli;
+    }
+
+    protected function getModuleContainerStub(): ModuleContainer
+    {
+        return $this->getMockBuilder(ModuleContainer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/packages/screenshots/Tests/Unit/Runner/Codeception/Support/Helper/Typo3CodeSnippetsTest.php
+++ b/packages/screenshots/Tests/Unit/Runner/Codeception/Support/Helper/Typo3CodeSnippetsTest.php
@@ -116,7 +116,7 @@ class Typo3CodeSnippetsTest extends UnitTestCase
 
         $typo3CodeSnippets = $this->getMockBuilder(Typo3CodeSnippets::class)
             ->setConstructorArgs([$this->getModuleContainerStub()])
-            ->setMethods(['getTypo3Screenshots'])
+            ->onlyMethods(['getTypo3Screenshots'])
             ->getMock();
         $typo3CodeSnippets->expects(self::any())->method('getTypo3Screenshots')->willReturn($typo3Screenshots);
 

--- a/packages/screenshots/Tests/Unit/Runner/Codeception/Support/Helper/Typo3CodeSnippetsTest.php
+++ b/packages/screenshots/Tests/Unit/Runner/Codeception/Support/Helper/Typo3CodeSnippetsTest.php
@@ -67,6 +67,12 @@ class Typo3CodeSnippetsTest extends UnitTestCase
     {
         return [
             [
+                'sourceFile' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . '/code-snippet.json',
+                'targetFileName' => 'code-snippet-json',
+                'targetFilePath' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'Documentation/CodeSnippets/code-snippet-json.rst.txt',
+                'expected' => 'code-block:: json'
+            ],
+            [
                 'sourceFile' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . '/code-snippet.php',
                 'targetFileName' => 'code-snippet-php',
                 'targetFilePath' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'Documentation/CodeSnippets/code-snippet-php.rst.txt',

--- a/packages/screenshots/Tests/Unit/Util/JsonHelperTest.php
+++ b/packages/screenshots/Tests/Unit/Util/JsonHelperTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\CMS\Screenshots\Tests\Unit\Util;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Screenshots\Util\JsonHelper;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class JsonHelperTest extends UnitTestCase
+{
+    /**
+     * @test
+     * @dataProvider extractFieldsFromJsonDataProvider
+     *
+     * @param string $json
+     * @param array $fields
+     * @param string $expected
+     */
+    public function extractFieldsFromJson(string $json, array $fields, string $expected): void
+    {
+        self::assertEquals($expected, trim(JsonHelper::extractFieldsFromJson($json, $fields)));
+    }
+
+    public function extractFieldsFromJsonDataProvider(): array
+    {
+        $json = file_get_contents(__DIR__ . '/../Fixtures/Json.json');
+
+        return [
+            [
+                'json' => $json,
+                'fields' => ['string'],
+                'expected' => <<<'NOWDOC'
+{
+    "string": "value"
+}
+NOWDOC
+            ],
+            [
+                'json' => $json,
+                'fields' => ['array/1'],
+                'expected' => <<<'NOWDOC'
+{
+    "array": {
+        "1": 2
+    }
+}
+NOWDOC
+            ],
+            [
+                'json' => $json,
+                'fields' => ['object/string'],
+                'expected' => <<<'NOWDOC'
+{
+    "object": {
+        "string": "value-3"
+    }
+}
+NOWDOC
+            ],
+            [
+                'json' => $json,
+                'fields' => ['string', 'object'],
+                'expected' => <<<'NOWDOC'
+{
+    "string": "value",
+    "object": {
+        "string": "value-3",
+        "number": 3,
+        "array": [
+            "value-3-1",
+            3.1000000000000001,
+            {
+                "string": "value-3-2-1: value-3-2-2, value-3-2-3",
+                "number": 3.2000000000000002
+            },
+            "value-3-3"
+        ]
+    }
+}
+NOWDOC
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function extractFieldsFromJsonCombinesPrettyJsonAndInlineJson(): void
+    {
+        $json = file_get_contents(__DIR__ . '/../Fixtures/Json.json');
+        $fields = ['object'];
+        $expected = <<<'NOWDOC'
+{
+    "object": {
+        "string": "value-3",
+        "number": 3,
+        "array": ["value-3-1", 3.1000000000000001, {"string": "value-3-2-1: value-3-2-2, value-3-2-3", "number": 3.2000000000000002}, "value-3-3"]
+    }
+}
+NOWDOC;
+
+        self::assertEquals($expected, JsonHelper::extractFieldsFromJson($json, $fields, 2));
+    }
+
+    /**
+     * @test
+     */
+    public function extractFieldsFromJsonIncludesFullDataIfFieldsAreEmpty(): void
+    {
+        $json = file_get_contents(__DIR__ . '/../Fixtures/Json.json');
+        $fields = [];
+
+        self::assertEquals(json_decode($json), json_decode(JsonHelper::extractFieldsFromJson($json, $fields)));
+    }
+
+    /**
+     * @test
+     */
+    public function extractFieldsFromJsonTriggersExceptionIfJsonIsEmpty(): void
+    {
+        $json = '';
+        $fields = [];
+
+        $this->expectException(\JsonException::class);
+
+        JsonHelper::extractFieldsFromJson($json, $fields);
+    }
+
+    /**
+     * @test
+     */
+    public function extractFieldsFromJsonTriggersExceptionIfJsonIsMalformed(): void
+    {
+        $json = <<<'NOWDOC'
+{
+    "key": "value",
+}
+NOWDOC;
+        $fields = [];
+
+        $this->expectException(\JsonException::class);
+
+        JsonHelper::extractFieldsFromJson($json, $fields);
+    }
+}


### PR DESCRIPTION
This PR is about the dedicated action `createJsonCodeSnippet` to store only excerpts of JSON files, e.g.

JSON file:
```
{
  "name": "typo3/screenshots",
  "type": "typo3-cms-extension",
  "description": "Provide tools and runner to take scripted screenshots of the TYPO3 CMS.",
  "authors": [
    {
      "name": "TYPO3 CMS Documentation Team",
      "role": "Developer",
      "homepage": "https://typo3.org/community/teams/documentation"
    },
    {
      "name": "The TYPO3 Community",
      "role": "Contributor",
      "homepage": "https://typo3.org/community/"
    }
  ]
}
```
Paths:
```
['name', 'description']
```
JSON excerpt:
```
{
  "name": "typo3/screenshots",
  "description": "Provide tools and runner to take scripted screenshots of the TYPO3 CMS."
}
```

Additionally a screenshot run quits immediately if a `screenshots.json` is malformed and the related error message provides the json file path, e.g.
```
[ERROR] 4: Syntax error in /var/www/html/public/t3docs/My-Manual/screenshots.json
```

Fixes: #160
Fixes: #161 