### PR TITLE
[BUGFIX] Laying drawings over modals

### DIFF
--- a/packages/screenshots/Classes/Configuration/Configuration.php
+++ b/packages/screenshots/Classes/Configuration/Configuration.php
@@ -427,6 +427,11 @@ class Configuration
                             ['action' => 'drawBox', 'selector' => 'h1'],
                             ['action' => 'drawArrow', 'selector' => 'h1', 'position' => 'center-bottom'],
                             ['action' => 'makeScreenshotOfFullPage', 'fileName' => "TxStyleguideElementsBasicWithHighlightsAndFullpage"],
+                            ['action' => 'click', 'link' => "(//*[contains(@class, \"t3js-record-delete\")])[1]"],
+                            ['action' => 'waitForModalDialogInMainFrame'],
+                            ['action' => 'drawArrow', 'selector' => 'button[name="cancel"]', 'position' => 'left-middle'],
+                            ['action' => 'makeScreenshotOfWindow', 'fileName' => "TxStyleguideElementsBasicWithModalHighlights"],
+                            ['action' => 'clickButtonInModalDialog', 'buttonLink' => "Cancel"],
                             ['action' => 'clearDrawings'],
                             ['action' => 'makeScreenshotOfFullPage', 'fileName' => "TxStyleguideElementsBasicWithClearedHighlightsAndFullpage"],
                         ]

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Draw.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Draw.php
@@ -44,7 +44,7 @@ class Typo3Draw extends Module
         "position" => "absolute",
         "top" => 0,
         "left" => 0,
-        "z-index" => 1001,
+        "z-index" => 1011,
         "pointer-events" => "none",
     ];
 


### PR DESCRIPTION
Modals have a z-index of 1010, so drawings should have at least a z-index of 1011 to be fully visible.

Example screenshots.json:
```javascript
..
{"action": "click", "link": "(//*[contains(@class, \"t3js-record-delete\")])[1]"},
{"action": "waitForModalDialogInMainFrame"},
{"action": "drawArrow", "selector": "button[name=\"cancel\"]", "position": "left-middle"},
{"action": "makeScreenshotOfWindow", "fileName": "TxStyleguideElementsBasicWithModalHighlights"},
..
```

![TxStyleguideElementsBasicWithModalHighlights](https://user-images.githubusercontent.com/20297232/125158258-16339c80-e170-11eb-8663-409594fedb10.png)

Fixes: #171 