### PR TITLE
[FEATURE] Support screenshot of TYPO3 backend content frame

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -216,11 +216,10 @@ This is a small runner configuration which takes screenshots of five TYPO3 envir
       }
    }
 
-Screenshots are mainly made by the actions ``makeScreenshotOfWindow``, ``makeScreenshotOfFullPage`` and
-``makeScreenshotOfElement``, the first one taking a screenshot of the browser window, the second one taking a screenshot
-of the whole TYPO3 page and the last one of a specific DOM element. A special use case for ``makeScreenshotOfElement``
-is to take a screenshot of the TYPO3 backend content frame, which is often the most interesting part for documentation,
-e.g.
+Screenshots are mainly made by the actions ``makeScreenshotOfWindow``, ``makeScreenshotOfFullPage``,
+``makeScreenshotOfContentFrame`` and ``makeScreenshotOfElement``, the first one taking a screenshot of the browser
+window, the second one taking a screenshot of the whole TYPO3 page, the third one only of the TYPO3 backend content
+frame and the last one of a specific DOM element, e.g.
 
 .. code-block:: json
 
@@ -232,10 +231,10 @@ e.g.
                        {"action": "see", "text": "List"},
                        {"action": "click", "link": "List"},
                        {"action": "waitForText", "text": "New TYPO3 site"},
-                       {"action": "makeScreenshotOfWindow", "fileName": "Typo3ListWindow"},
-                       {"action": "makeScreenshotOfFullPage", "fileName": "Typo3ListFullPage"},
-                       {"action": "makeScreenshotOfElement", "selector": "#typo3-contentIframe", "fileName": "Typo3ListContentFrameOnly"},
-                       {"action": "makeScreenshotOfElement", "selector": ".topbar-header-site", "fileName": "Typo3ListElementOnly"}
+                       {"action": "makeScreenshotOfWindow", "fileName": "Typo3Window"},
+                       {"action": "makeScreenshotOfFullPage", "fileName": "Typo3FullPage"},
+                       {"action": "makeScreenshotOfContentFrame", "fileName": "Typo3ContentFrameOnly"},
+                       {"action": "makeScreenshotOfElement", "selector": ".topbar-header-site", "fileName": "Typo3ElementOnly"}
                    ]
                ]
            }

--- a/README.rst
+++ b/README.rst
@@ -216,6 +216,32 @@ This is a small runner configuration which takes screenshots of five TYPO3 envir
       }
    }
 
+Screenshots are mainly made by the actions ``makeScreenshotOfWindow``, ``makeScreenshotOfFullPage`` and
+``makeScreenshotOfElement``, the first one taking a screenshot of the browser window, the second one taking a screenshot
+of the whole TYPO3 page and the last one of a specific DOM element. A special use case for ``makeScreenshotOfElement``
+is to take a screenshot of the TYPO3 backend content frame, which is often the most interesting part for documentation,
+e.g.
+
+.. code-block:: json
+
+   {
+       "suites": {
+           "Core": {
+               "screenshots": [
+                   [
+                       {"action": "see", "text": "List"},
+                       {"action": "click", "link": "List"},
+                       {"action": "waitForText", "text": "New TYPO3 site"},
+                       {"action": "makeScreenshotOfWindow", "fileName": "Typo3ListWindow"},
+                       {"action": "makeScreenshotOfFullPage", "fileName": "Typo3ListFullPage"},
+                       {"action": "makeScreenshotOfElement", "selector": "#typo3-contentIframe", "fileName": "Typo3ListContentFrameOnly"},
+                       {"action": "makeScreenshotOfElement", "selector": ".topbar-header-site", "fileName": "Typo3ListElementOnly"}
+                   ]
+               ]
+           }
+       }
+   }
+
 The target folder of the screenshots is ``Documentation/Images/AutomaticScreenshots`` by default and is calculated
 relative to the ``screenshots.json``. The path can be adapted by the actions ``setScreenshotsDocumentationPath`` and
 ``setScreenshotsImagePath`` respectively, e.g.

--- a/packages/screenshots/Classes/Configuration/Configuration.php
+++ b/packages/screenshots/Classes/Configuration/Configuration.php
@@ -209,7 +209,11 @@ class Configuration
                             ['action' => 'resizeWindow', 'width' => 1024, 'height' => 768],
                             ['action' => 'see', 'text' => "List"],
                             ['action' => 'click', 'link' => "List"],
-                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => "Typo3DashboardFullPage"],
+                            ['action' => 'waitForText', 'text' => "New TYPO3 site"],
+                            ['action' => 'makeScreenshotOfWindow', 'fileName' => "Typo3ListWindow"],
+                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => "Typo3ListFullPage"],
+                            ['action' => 'makeScreenshotOfElement', 'selector' => "#typo3-contentIframe", 'fileName' => "Typo3ListContentFrameOnly"],
+                            ['action' => 'makeScreenshotOfElement', 'selector' => ".topbar-header-site", 'fileName' => "Typo3ListElementOnly"],
                         ]
                     ]
                 ],

--- a/packages/screenshots/Classes/Configuration/Configuration.php
+++ b/packages/screenshots/Classes/Configuration/Configuration.php
@@ -210,10 +210,12 @@ class Configuration
                             ['action' => 'see', 'text' => "List"],
                             ['action' => 'click', 'link' => "List"],
                             ['action' => 'waitForText', 'text' => "New TYPO3 site"],
-                            ['action' => 'makeScreenshotOfWindow', 'fileName' => "Typo3ListWindow"],
-                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => "Typo3ListFullPage"],
-                            ['action' => 'makeScreenshotOfElement', 'selector' => "#typo3-contentIframe", 'fileName' => "Typo3ListContentFrameOnly"],
-                            ['action' => 'makeScreenshotOfElement', 'selector' => ".topbar-header-site", 'fileName' => "Typo3ListElementOnly"],
+                            ['action' => 'makeScreenshotOfWindow', 'fileName' => "Typo3Window"],
+                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => "Typo3FullPage"],
+                            ['action' => 'makeScreenshotOfElement', 'selector' => ".topbar-header-site", 'fileName' => "Typo3ElementOnly"],
+                            ['action' => 'makeScreenshotOfContentFrame', 'fileName' => "Typo3ContentFrameInMainFrame"],
+                            ['action' => 'switchToContentFrame'],
+                            ['action' => 'makeScreenshotOfContentFrame', 'fileName' => "Typo3ContentFrameInContentFrame"],
                         ]
                     ]
                 ],

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Screenshots.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Screenshots.php
@@ -208,6 +208,13 @@ class Typo3Screenshots extends Module
     /**
      * Take screenshot of the browser window or of a DOM element - if $selector is specified.
      *
+     * Also use this action to take a screenshot of only the TYPO3 backend content frame with:
+     * ``` php
+     * <?php
+     * $I->makeScreenshotOfElement("Typo3ContentFrameOnly", "#typo3-contentIframe");
+     * ?>
+     * ```
+     *
      * Attention: If the screenshot of a DOM element looks broken, resize the window to full page before taking the
      * screenshot. Therefore, replace this action with:
      * ``` php

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Screenshots.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Screenshots.php
@@ -115,6 +115,23 @@ class Typo3Screenshots extends Module
     }
 
     /**
+     * Take screenshot of the TYPO3 backend content frame.
+     *
+     * @param string $fileName
+     * @param string $altText
+     * @param string $captionText
+     * @param string $captionReference
+     */
+    public function makeScreenshotOfContentFrame(string $fileName, string $altText = '', string $captionText = '', string $captionReference = ''): void
+    {
+        if ($this->getTypo3Navigation()->_isOnMainFrame()) {
+            $this->makeScreenshotOfElement($fileName, '[name=list_frame]', $altText, $captionText, $captionReference);
+        } else {
+            $this->makeScreenshotOfElement($fileName, 'body', $altText, $captionText, $captionReference);
+        }
+    }
+
+    /**
      * Take screenshot of a TYPO3 backend records table form.
      *
      * Attention: If the screenshot looks broken, resize the window to full page before taking the screenshot.
@@ -207,13 +224,6 @@ class Typo3Screenshots extends Module
 
     /**
      * Take screenshot of the browser window or of a DOM element - if $selector is specified.
-     *
-     * Also use this action to take a screenshot of only the TYPO3 backend content frame with:
-     * ``` php
-     * <?php
-     * $I->makeScreenshotOfElement("Typo3ContentFrameOnly", "#typo3-contentIframe");
-     * ?>
-     * ```
      *
      * Attention: If the screenshot of a DOM element looks broken, resize the window to full page before taking the
      * screenshot. Therefore, replace this action with:


### PR DESCRIPTION
To take a screenshot of the TYPO3 backend content frame only, use the new `makeScreenshotOfContentFrame` action. It takes the screenshot being in the main frame as well as in the content frame itself.

`makeScreenshotOfWindow`

![Typo3Window](https://user-images.githubusercontent.com/20297232/125162177-bd233300-e186-11eb-944c-e44f6f66c460.png)

`makeScreenshotOfContentFrame`

![Typo3ContentFrameInContentFrame](https://user-images.githubusercontent.com/20297232/125162188-c90ef500-e186-11eb-9026-d30177dc1c47.png)

Fixes: #172 