### PR TITLE
[FEATURE] Support cropping of screenshot

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,6 +241,25 @@ frame and the last one of a specific DOM element, e.g.
        }
    }
 
+The captured screenshot might contain too much information that is not needed for the documentation. Therefore it can
+be cropped for the purpose of the documentation - or the width of the documentation page - with ``cropScreenshot``,
+e.g.
+
+.. code-block:: json
+
+   {
+      "suites": {
+         "Introduction": {
+            "screenshots": [
+               [
+                    {"action": "makeScreenshotOfFullPage", "fileName": "IntroductionCropRightTop"},
+                    {"action": "cropScreenshot", "fileName": "IntroductionCropRightTop", "position": "right-top", "height": 400, "width": 400},
+               ]
+            ]
+         }
+      }
+   }
+
 The target folder of the screenshots is ``Documentation/Images/AutomaticScreenshots`` by default and is calculated
 relative to the ``screenshots.json``. The path can be adapted by the actions ``setScreenshotsDocumentationPath`` and
 ``setScreenshotsImagePath`` respectively, e.g.

--- a/packages/screenshots/Classes/Configuration/Configuration.php
+++ b/packages/screenshots/Classes/Configuration/Configuration.php
@@ -440,7 +440,19 @@ class Configuration
                             ['action' => 'clickButtonInModalDialog', 'buttonLink' => "Cancel"],
                             ['action' => 'clearDrawings'],
                             ['action' => 'makeScreenshotOfFullPage', 'fileName' => "TxStyleguideElementsBasicWithClearedHighlightsAndFullpage"],
-                        ]
+                            ['action' => 'reloadBackend'],
+                        ],
+                        'actionsIdentifierCrop' => [
+                            ['include' => '_default'],
+                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => "StyleguideDashboardCropTop"],
+                            ['action' => 'cropScreenshot', 'fileName' => "StyleguideDashboardCropTop", 'height' => 400],
+                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => "StyleguideDashboardCropBottom"],
+                            ['action' => 'cropScreenshot', 'fileName' => "StyleguideDashboardCropBottom", 'position' => 'left-bottom', 'height' => 400],
+                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => "StyleguideDashboardCropRightTop"],
+                            ['action' => 'cropScreenshot', 'fileName' => "StyleguideDashboardCropRightTop", 'position' => 'right-top', 'height' => 400, 'width' => 400],
+                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => "StyleguideDashboardCropRightBottom"],
+                            ['action' => 'cropScreenshot', 'fileName' => "StyleguideDashboardCropRightBottom", 'position' => 'right-bottom', 'height' => 400, 'width' => 400],
+                        ],
                     ]
                 ]
             ]

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Draw.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Draw.php
@@ -23,19 +23,18 @@ use TYPO3\CMS\Screenshots\Util\JsonHelper;
  */
 class Typo3Draw extends Module
 {
-    public const ARROW_LEFT_TOP = 'left-top';
-    public const ARROW_LEFT_MIDDLE = 'left-middle';
-    public const ARROW_LEFT_BOTTOM = 'left-bottom';
-    public const ARROW_CENTER_TOP = 'center-top';
-    public const ARROW_CENTER_BOTTOM = 'center-bottom';
-    public const ARROW_RIGHT_TOP = 'right-top';
-    public const ARROW_RIGHT_MIDDLE = 'right-middle';
-    public const ARROW_RIGHT_BOTTOM = 'right-bottom';
-
-    public const BADGE_RIGHT = 'right';
-    public const BADGE_LEFT = 'left';
-    public const BADGE_TOP = 'top';
-    public const BADGE_BOTTOM = 'bottom';
+    public const POSITION_LEFT = 'left';
+    public const POSITION_RIGHT = 'right';
+    public const POSITION_TOP = 'top';
+    public const POSITION_BOTTOM = 'bottom';
+    public const POSITION_LEFT_TOP = 'left-top';
+    public const POSITION_LEFT_MIDDLE = 'left-middle';
+    public const POSITION_LEFT_BOTTOM = 'left-bottom';
+    public const POSITION_CENTER_TOP = 'center-top';
+    public const POSITION_CENTER_BOTTOM = 'center-bottom';
+    public const POSITION_RIGHT_TOP = 'right-top';
+    public const POSITION_RIGHT_MIDDLE = 'right-middle';
+    public const POSITION_RIGHT_BOTTOM = 'right-bottom';
 
     /**
      * @var string[]
@@ -112,7 +111,7 @@ NOWDOC;
      *                          "left-bottom", "center-top", "center-bottom", "right-top", "right-middle",
      *                          "right-bottom".
      */
-    public function drawArrow(string $selector, string $position = self::ARROW_RIGHT_TOP): void
+    public function drawArrow(string $selector, string $position = self::POSITION_RIGHT_TOP): void
     {
         if (!$this->isValidArrowPosition($position)) {
             throw new \Exception(sprintf('Arrow position "%s" is invalid.', $position), 4001);
@@ -186,14 +185,14 @@ NOWDOC;
     protected function isValidArrowPosition(string $position): bool
     {
         return in_array($position, [
-            self::ARROW_LEFT_TOP,
-            self::ARROW_LEFT_MIDDLE,
-            self::ARROW_LEFT_BOTTOM,
-            self::ARROW_CENTER_TOP,
-            self::ARROW_CENTER_BOTTOM,
-            self::ARROW_RIGHT_TOP,
-            self::ARROW_RIGHT_MIDDLE,
-            self::ARROW_RIGHT_BOTTOM,
+            self::POSITION_LEFT_TOP,
+            self::POSITION_LEFT_MIDDLE,
+            self::POSITION_LEFT_BOTTOM,
+            self::POSITION_CENTER_TOP,
+            self::POSITION_CENTER_BOTTOM,
+            self::POSITION_RIGHT_TOP,
+            self::POSITION_RIGHT_MIDDLE,
+            self::POSITION_RIGHT_BOTTOM,
         ]);
     }
 
@@ -206,7 +205,7 @@ NOWDOC;
      * @param string $label The badge text, e.g. "Click here" or "#1".
      * @param string $position The position of the badge regarding the element: "left", "top", "right" or "bottom".
      */
-    public function drawBadge(string $selector, string $label, string $position = self::BADGE_BOTTOM): void
+    public function drawBadge(string $selector, string $label, string $position = self::POSITION_BOTTOM): void
     {
         if (!$this->isValidBadgePosition($position)) {
             throw new \Exception(sprintf('Badge position "%s" is invalid.', $position), 4002);
@@ -275,10 +274,10 @@ NOWDOC;
     protected function isValidBadgePosition(string $position): bool
     {
         return in_array($position, [
-            self::BADGE_LEFT,
-            self::BADGE_RIGHT,
-            self::BADGE_TOP,
-            self::BADGE_BOTTOM,
+            self::POSITION_LEFT,
+            self::POSITION_RIGHT,
+            self::POSITION_TOP,
+            self::POSITION_BOTTOM,
         ]);
     }
 

--- a/packages/screenshots/Classes/Util/MathHelper.php
+++ b/packages/screenshots/Classes/Util/MathHelper.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\CMS\Screenshots\Util;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+class MathHelper
+{
+    /**
+     * Determines position and dimension of an inner rectangle in relation to an outer rectangle.
+     *
+     * If the x-coordinate of the inner rectangle is negative, it is calculated from the right edge of the outer
+     * rectangle. The same is true for the y-coordinate.
+     * If the width of the inner rectangle is 0, it is expanded to the remaining width of the outer rectangle. The same
+     * is true for the height.
+     * If the width of the inner rectangle is negative, it is expanded to the remaining width of the outer rectangle
+     * minus the specified width. The same applies to the height.
+     *
+     * @param int $x
+     * @param int $y
+     * @param int $width
+     * @param int $height
+     * @param int $outerWidth
+     * @param int $outerHeight
+     * @return array
+     */
+    public static function getRectangleInRectangle(
+        int $x,
+        int $y,
+        int $width,
+        int $height,
+        int $outerWidth,
+        int $outerHeight
+    ): array {
+        $x = $x < 0 ? $outerWidth - -$x : $x;
+        $y = $y < 0 ? $outerHeight - -$y : $y;
+        $width = $width > 0 ? min($width, $outerWidth - $x) : $outerWidth - $x - -$width;
+        $height = $height > 0 ? min($height, $outerHeight - $y) : $outerHeight - $y - -$height;
+        return ["x" => $x, "y" => $y, "width" => $width, "height" => $height];
+    }
+}

--- a/packages/screenshots/Tests/Unit/Configuration/ConfigurationTest.php
+++ b/packages/screenshots/Tests/Unit/Configuration/ConfigurationTest.php
@@ -150,6 +150,7 @@ class ConfigurationTest extends UnitTestCase
             'actionsIdentifierScreenshotsOfContentFrameOnly',
             'actionsIdentifierCodeSnippets',
             'actionsIdentifierDraw',
+            'actionsIdentifierCrop',
         ];
         self::assertEquals($expectedActionsIds, $actualActionsIds);
     }

--- a/packages/screenshots/Tests/Unit/Runner/Codeception/Support/Helper/Typo3ScreenshotsTest.php
+++ b/packages/screenshots/Tests/Unit/Runner/Codeception/Support/Helper/Typo3ScreenshotsTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\CMS\Screenshots\Tests\Unit\Runner\Codeception\Support\Helper;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Codeception\Lib\ModuleContainer;
+use org\bovigo\vfs\vfsStream;
+use TYPO3\CMS\Screenshots\Runner\Codeception\Support\Helper\Typo3Screenshots;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class Typo3ScreenshotsTest extends UnitTestCase
+{
+    protected string $vfsPath;
+    protected string $fixturePath = __DIR__ . '/../../../../Fixtures';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vfsPath = vfsStream::setup('public')->url();
+    }
+
+    /**
+     * @test
+     */
+    public function cropScreenshot(): void
+    {
+        $fileName = 'screenshot-actual.png';
+        $width = 150;
+        $height = 100;
+
+        $sourcePath = $this->fixturePath . DIRECTORY_SEPARATOR . $fileName;
+        $targetPaths = [
+            sprintf('%s-%s.png',
+                $this->vfsPath . DIRECTORY_SEPARATOR . pathinfo($fileName, PATHINFO_FILENAME),
+                Typo3Screenshots::POSITION_LEFT_TOP
+            ),
+            sprintf('%s-%s.png',
+                $this->vfsPath . DIRECTORY_SEPARATOR . pathinfo($fileName, PATHINFO_FILENAME),
+                Typo3Screenshots::POSITION_LEFT_BOTTOM
+            ),
+            sprintf('%s-%s.png',
+                $this->vfsPath . DIRECTORY_SEPARATOR . pathinfo($fileName, PATHINFO_FILENAME),
+                Typo3Screenshots::POSITION_RIGHT_TOP
+            ),
+            sprintf('%s-%s.png',
+                $this->vfsPath . DIRECTORY_SEPARATOR . pathinfo($fileName, PATHINFO_FILENAME),
+                Typo3Screenshots::POSITION_RIGHT_BOTTOM
+            )
+        ];
+
+        copy($sourcePath, $targetPaths[0]);
+        copy($sourcePath, $targetPaths[1]);
+        copy($sourcePath, $targetPaths[2]);
+        copy($sourcePath, $targetPaths[3]);
+
+        $typo3Screenshots = $this->getTypo3ScreenshotsMock();
+        $typo3Screenshots->setScreenshotsBasePath($this->vfsPath);
+        $typo3Screenshots->setScreenshotsDocumentationPath("");
+        $typo3Screenshots->setScreenshotsImagePath("");
+
+        $typo3Screenshots->cropScreenshot(
+            pathinfo($targetPaths[0], PATHINFO_FILENAME), Typo3Screenshots::POSITION_LEFT_TOP, $width, $height
+        );
+        $typo3Screenshots->cropScreenshot(
+            pathinfo($targetPaths[1], PATHINFO_FILENAME), Typo3Screenshots::POSITION_LEFT_BOTTOM, $width, $height
+        );
+        $typo3Screenshots->cropScreenshot(
+            pathinfo($targetPaths[2], PATHINFO_FILENAME), Typo3Screenshots::POSITION_RIGHT_TOP, $width, $height
+        );
+        $typo3Screenshots->cropScreenshot(
+            pathinfo($targetPaths[3], PATHINFO_FILENAME), Typo3Screenshots::POSITION_RIGHT_BOTTOM, $width, $height
+        );
+
+        self::assertEquals([$width, $height], array_slice(getimagesize($targetPaths[0]), 0, 2));
+        self::assertEquals([$width, $height], array_slice(getimagesize($targetPaths[1]), 0, 2));
+        self::assertEquals([$width, $height], array_slice(getimagesize($targetPaths[2]), 0, 2));
+        self::assertEquals([$width, $height], array_slice(getimagesize($targetPaths[3]), 0, 2));
+
+        self::assertFileNotEquals($targetPaths[0], $targetPaths[1]);
+        self::assertFileNotEquals($targetPaths[0], $targetPaths[2]);
+        self::assertFileNotEquals($targetPaths[0], $targetPaths[3]);
+    }
+
+    protected function getTypo3ScreenshotsMock(): Typo3Screenshots
+    {
+        $typo3Screenshots = $this->getMockBuilder(Typo3Screenshots::class)
+            ->setConstructorArgs([$this->getModuleContainerStub()])
+            ->addMethods(['dummy'])
+            ->getMock();
+
+        return $typo3Screenshots;
+    }
+
+    protected function getModuleContainerStub(): ModuleContainer
+    {
+        return $this->getMockBuilder(ModuleContainer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/packages/screenshots/Tests/Unit/Util/MathHelperTest.php
+++ b/packages/screenshots/Tests/Unit/Util/MathHelperTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\CMS\Screenshots\Tests\Unit\Util;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Screenshots\Util\MathHelper;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+class MathHelperTest extends UnitTestCase
+{
+    /**
+     * @test
+     * @dataProvider getRectangleInRectangleDataProvider
+     *
+     * @param int $x
+     * @param int $y
+     * @param int $width
+     * @param int $height
+     * @param int $outerWidth
+     * @param int $outerHeight
+     */
+    public function getRectangleInRectangle(
+        int $x,
+        int $y,
+        int $width,
+        int $height,
+        int $outerWidth,
+        int $outerHeight,
+        array $expected
+    ): void {
+        self::assertEquals(
+            $expected,
+            MathHelper::getRectangleInRectangle($x, $y, $width, $height, $outerWidth, $outerHeight)
+        );
+    }
+
+    public function getRectangleInRectangleDataProvider(): array
+    {
+        return [
+            'rectangle-fully-in-rectangle' => [
+                'x' => 100,
+                'y' => 50,
+                'width' => 400,
+                'height' => 250,
+                'outerWidth' => 800,
+                'outerHeight' => 600,
+                'expected' => ['x' => 100, 'y' => 50, 'width' => 400, 'height' => 250]
+            ],
+            'rectangle-exceeds-rectangle' => [
+                'x' => 100,
+                'y' => 50,
+                'width' => 800,
+                'height' => 650,
+                'outerWidth' => 800,
+                'outerHeight' => 600,
+                'expected' => ['x' => 100, 'y' => 50, 'width' => 700, 'height' => 550]
+            ],
+            'rectangle-with-distance-to-right-and-bottom-boundaries' => [
+                'x' => 100,
+                'y' => 50,
+                'width' => -321,
+                'height' => -123,
+                'outerWidth' => 800,
+                'outerHeight' => 600,
+                'expected' => ['x' => 100, 'y' => 50, 'width' => 379, 'height' => 427]
+            ],
+            'rectangle-with-position-from-right-and-bottom-boundaries' => [
+                'x' => -444,
+                'y' => -222,
+                'width' => 222,
+                'height' => 111,
+                'outerWidth' => 800,
+                'outerHeight' => 600,
+                'expected' => ['x' => 356, 'y' => 378, 'width' => 222, 'height' => 111]
+            ],
+            'rectangle-with-position-and-distance-from-right-and-bottom-boundaries' => [
+                'x' => -444,
+                'y' => -222,
+                'width' => -24,
+                'height' => -12,
+                'outerWidth' => 800,
+                'outerHeight' => 600,
+                'expected' => ['x' => 356, 'y' => 378, 'width' => 420, 'height' => 210]
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
To crop a screenshot, use the new `cropScreenshot` action. It crops the screenshot along a specified cropping range given by position, width and height. If width is omitted, the entire width of the image is taken into account. The same is true for height. 

For example:

```json
..
{"action": "makeScreenshotOfFullPage", "fileName": "StyleguideDashboardCropTop"},
{"action": "cropScreenshot", "fileName": "StyleguideDashboardCropTop", "height": 400},
{"action": "makeScreenshotOfFullPage", "fileName": "StyleguideDashboardCropRightTop"},
{"action": "cropScreenshot", "fileName": "StyleguideDashboardCropRightTop", "position": "right-top", "height": 400, "width": 400}
..
```

`StyleguideDashboardCropTop.png`
![StyleguideDashboardCropTop](https://user-images.githubusercontent.com/20297232/125199200-5f194d00-e265-11eb-9ee4-0a1272c6dc26.png)

`StyleguideDashboardCropRightTop.png`
![StyleguideDashboardCropRightTop](https://user-images.githubusercontent.com/20297232/125199104-ff22a680-e264-11eb-81e6-7982d0a57e34.png)

Fixes: #178 
