### PR TITLE
[BUGFIX] Fixes opening a page tree with more than 1 level

### DIFF
--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/AbstractTypo3Tree.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/AbstractTypo3Tree.php
@@ -126,6 +126,7 @@ abstract class AbstractTypo3Tree extends Module
         $node = $tree->findElement(WebDriverBy::xpath('//*[text()=\'' . $nodeText . '\']/..'));
         try {
             $node->findElement(WebDriverBy::cssSelector('.chevron.collapsed'))->click();
+            $webDriver->wait(0.1);
         } catch (NoSuchElementException $e) {
             // element not found so it may be already opened...
         } catch (ElementNotInteractableException $e) {

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3PageTree.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3PageTree.php
@@ -21,6 +21,8 @@ namespace TYPO3\CMS\Screenshots\Runner\Codeception\Support\Helper;
  *   to prevent additional injections in testing classes
  * - considering the configuration param "wait" of module "WebDriver"
  *   when opening the page tree path and the page tree is not visible immediately
+ * - waits 0.1s per page tree level before opening the next page tree node
+ *   as the levels get loaded via AJAX
  *
  * @see \TYPO3\TestingFramework\Core\Acceptance\Helper\AbstractPageTree
  */


### PR DESCRIPTION
The `AbstractPageTree::openTreePath` action tries to open the child element without waiting for all children to be loaded via AJAX.

This fix temporarily solves the problem by inserting a fixed pause of 0.1s after opening a tree node - but this is not an intelligent solution.

See issue https://github.com/TYPO3/testing-framework/issues/245 for more details.

Fixes: #182 