### PR TITLE
[BUGFIX] Add waitForElement action on styleguide example json

### DIFF
--- a/packages/screenshots/Classes/Configuration/Configuration.php
+++ b/packages/screenshots/Classes/Configuration/Configuration.php
@@ -348,6 +348,7 @@ class Configuration
                             ['action' => 'waitForText', 'text' => 'Maintenance', 'timeout' => 5],
                             ['action' => 'click', 'link' => 'Manage languages'],
                             ['action' => 'waitForModalDialogInMainFrame'],
+                            ['action' => 'waitForElement', 'element' => '.t3js-languagePacks-mainContent'],
                             ['action' => 'scrollModalDialogBodyTo', 'toSelector' => '.t3js-languagePacks-mainContent'],
                             ['action' => 'makeScreenshotOfWindow', 'fileName' => "ModalDialogBodyScrolledToElement"],
                             ['action' => 'closeModalDialog'],


### PR DESCRIPTION
The action is added to prevent an error on some slow loading systems when the element is not ready yet.