### PR TITLE
[TASK] Move `screenshots.json` to subfolder `Documentation/`

### DIFF
--- a/.ddev/commands/web/make-screenshots
+++ b/.ddev/commands/web/make-screenshots
@@ -2,8 +2,8 @@
 
 ## Description: Make screenshots via codeception inside the web container
 ## Usage: make-screenshots
-## Example: make-screenshots\nmake-screenshots -s Styleguide\nmake-screenshots -s Styleguide -a actionsIdentifierScreenshots\nmake-screenshots -t TYPO3CMS-Reference-TCA/Documentation
-## Flags: [{"Name":"actions-id","Shorthand":"a","Type":"string","Usage":"Run actions of specific ID only. Actions of all IDs if empty."},{"Name":"suite-id","Shorthand":"s","Type":"string","Usage":"Run actions of specific TYPO3 environment suite ID only (Core, Examples, Install, Introduction, SitePackage, Styleguide). All suites if empty."},{"Name":"target-path","Shorthand":"t","Type":"string","Usage":"Run actions of specific folder only (relative or absolute path). All folders if empty."}]
+## Example: make-screenshots\nmake-screenshots -s Styleguide\nmake-screenshots -s Styleguide -a actionsIdentifierScreenshots\nmake-screenshots -t TYPO3CMS-Reference-TCA
+## Flags: [{"Name":"actions-id","Shorthand":"a","Type":"string","Usage":"Run actions of specific ID only. Actions of all IDs if empty."},{"Name":"suite-id","Shorthand":"s","Type":"string","Usage":"Run actions of specific TYPO3 environment suite ID only (Core, Examples, Install, Introduction, SitePackage, Styleguide). All suites if empty."},{"Name":"target-path","Shorthand":"t","Type":"string","Usage":"Run actions of specific folder and its subfolders only (relative or absolute path). All folders if empty."}]
 
 SUITE_ID=""
 TARGET_PATH=""

--- a/.ddev/commands/web/make-screenshots
+++ b/.ddev/commands/web/make-screenshots
@@ -2,7 +2,7 @@
 
 ## Description: Make screenshots via codeception inside the web container
 ## Usage: make-screenshots
-## Example: make-screenshots\nmake-screenshots -s Styleguide\nmake-screenshots -s Styleguide -a actionsIdentifierScreenshots\nmake-screenshots -t My-Manual
+## Example: make-screenshots\nmake-screenshots -s Styleguide\nmake-screenshots -s Styleguide -a actionsIdentifierScreenshots\nmake-screenshots -t TYPO3CMS-Reference-TCA/Documentation
 ## Flags: [{"Name":"actions-id","Shorthand":"a","Type":"string","Usage":"Run actions of specific ID only. Actions of all IDs if empty."},{"Name":"suite-id","Shorthand":"s","Type":"string","Usage":"Run actions of specific TYPO3 environment suite ID only (Core, Examples, Install, Introduction, SitePackage, Styleguide). All suites if empty."},{"Name":"target-path","Shorthand":"t","Type":"string","Usage":"Run actions of specific folder only (relative or absolute path). All folders if empty."}]
 
 SUITE_ID=""

--- a/README.rst
+++ b/README.rst
@@ -297,7 +297,7 @@ e.g.
       }
    }
 
-The target folder of the screenshots is ``Documentation/Images/AutomaticScreenshots`` by default and is calculated
+The target folder of the screenshots is ``Images/AutomaticScreenshots`` by default and is calculated
 relative to the ``screenshots.json``. The path can be adapted by the actions ``setScreenshotsDocumentationPath`` and
 ``setScreenshotsImagePath`` respectively, e.g.
 
@@ -316,6 +316,8 @@ relative to the ``screenshots.json``. The path can be adapted by the actions ``s
          }
       }
    }
+
+which would result in a target folder ``IntroductionDocumentation/Images/IntroductionScreenshots``.
 
 To steer the runner through the TYPO3 backend, many TYPO3 specific actions have been added to the general browser
 navigation actions, e.g.
@@ -364,7 +366,7 @@ To guide the reader of the documentation over the screenshot, DOM elements can b
       }
    }
 
-Along with the screenshot a reStructuredText file gets created automatically in the folder ``Documentation/Images/Rst``
+Along with the screenshot a reStructuredText file gets created automatically in the folder ``Images/Rst``
 and can be used to include the screenshot comfortably into a documentation. The path can be changed by the actions
 ``setScreenshotsDocumentationPath`` and ``setScreenshotsRstPath`` and the automatic creation can be switched via action
 ``createScreenshotsRstFile``, e.g.
@@ -387,12 +389,15 @@ and can be used to include the screenshot comfortably into a documentation. The 
       }
    }
 
+which would result in a target folder ``IntroductionDocumentation/Images/IntroductionRst`` for reStructuredText files.
+
 Another redundant documentation job besides taking screenshots is to insert and update code snippets. With action
 ``createCodeSnippet`` a specific TYPO3 code source file gets transformed into a reStructuredText file for inclusion and
-gets saved to folder ``Documentation/CodeSnippets``. The folder can be changed by ``setCodeSnippetsTargetPath``.
+gets saved to folder ``CodeSnippets``. The folder can be changed by ``setScreenshotsDocumentationPath`` and
+``setCodeSnippetsTargetPath``.
 Furthermore there are dedicated actions like ``createJsonCodeSnippet``, ``createPhpArrayCodeSnippet``,
 ``createPhpClassCodeSnippet``, ``createXmlCodeSnippet`` or ``createYamlCodeSnippet`` to store only excerpts of code
-files.
+files, e.g.
 
 .. code-block:: json
 
@@ -401,6 +406,7 @@ files.
          "Styleguide": {
             "screenshots": [
                [
+                  {"action": "setScreenshotsDocumentationPath", "path": "StyleguideDocumentation"},
                   {"action": "setCodeSnippetsTargetPath", "path": "CodeSnippets/StyleguideCode"},
                   {"action": "createCodeSnippet", "sourceFile": "typo3/sysext/core/Configuration/TCA/be_groups.php", "targetFileName": "CoreBeGroups"},
                   {
@@ -423,6 +429,8 @@ files.
          }
       }
    }
+
+which would result in a target folder ``StyleguideDocumentation/CodeSnippets/StyleguideCode`` for code snippets.
 
 Actions can be nested to use the return value of the inner action by the outer, e.g.
 

--- a/README.rst
+++ b/README.rst
@@ -583,16 +583,16 @@ Make all screenshots
 
    ddev make-screenshots
 
-Make screenshots of specific ``screenshots.json`` file
-------------------------------------------------------
+Make screenshots of specific folder only
+----------------------------------------
 
-A folder path can be specified to execute only the actions of this particular ``screenshots.json``. The folder path can
-be defined as an absolute path or relative to ``public/t3docs``, e.g. this command executes only
-``public/t3docs/My-Manual/screenshots.json``.
+A folder path can be specified to process only the ``screenshots.json`` of this particular folder and its subfolders.
+The folder path can be defined as an absolute path or relative to ``public/t3docs``, e.g. this command executes
+``public/t3docs/TYPO3CMS-Reference-TCA/Documentation/screenshots.json``.
 
 .. code-block:: bash
 
-   ddev make-screenshots -t My-Manual
+   ddev make-screenshots -t TYPO3CMS-Reference-TCA
 
 Make screenshots of TYPO3 installation process
 ----------------------------------------------

--- a/packages/screenshots/Classes/Configuration/Configuration.php
+++ b/packages/screenshots/Classes/Configuration/Configuration.php
@@ -20,7 +20,7 @@ use TYPO3\Documentation\Screenshots\Util\JsonHelper;
  */
 class Configuration
 {
-    protected string $fileName = 'screenshots.json';
+    public static string $fileName = 'screenshots.json';
 
     protected string $path;
     protected array $config;
@@ -46,7 +46,7 @@ class Configuration
 
     public function getFilePath(): string
     {
-        return $this->path . '/' . $this->fileName;
+        return $this->path . '/' . self::$fileName;
     }
 
     public function read(): void

--- a/packages/screenshots/Classes/Configuration/ConfigurationRepository.php
+++ b/packages/screenshots/Classes/Configuration/ConfigurationRepository.php
@@ -32,29 +32,21 @@ class ConfigurationRepository implements SingletonInterface
      */
     public function findAll(): array
     {
-        $configurations = [];
-
-        $paths = FileHelper::getSubFolders($this->basePath);
-        foreach ($paths as $path) {
-            $configuration = new Configuration($path);
-            if ($configuration->isExisting()) {
-                $configurations[] = $configuration;
-            }
-        }
-
-        return $configurations;
+        return $this->findByPath($this->basePath);
     }
 
     /**
-     * @param string $path
+     * @param string $folderPath
      * @return Configuration[]
      */
-    public function findByPath(string $path): array
+    public function findByPath(string $folderPath): array
     {
         $configurations = [];
 
-        $configuration = new Configuration($this->getAbsolutePath($path));
-        if ($configuration->isExisting()) {
+        $filePaths = FileHelper::getFilesByNameRecursively(Configuration::$fileName, $this->getAbsolutePath($folderPath));
+        foreach ($filePaths as $filePath) {
+            $folderPath = dirname($filePath);
+            $configuration = new Configuration($folderPath);
             $configurations[] = $configuration;
         }
 

--- a/packages/screenshots/Classes/Runner/Codeception/AbstractBaseCest.php
+++ b/packages/screenshots/Classes/Runner/Codeception/AbstractBaseCest.php
@@ -61,7 +61,7 @@ abstract class AbstractBaseCest
 
         foreach ($configurations as &$configuration) {
             $originalDirectory = $configuration->getPath();
-            $actualDirectory = FileHelper::getPathBySegments($actualPath, basename($originalDirectory));
+            $actualDirectory = FileHelper::getPathBySegments($actualPath, substr($originalDirectory, strlen($originalPath)));
             $I->setScreenshotsBasePath($actualDirectory);
 
             $configuration->read();

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Screenshots.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Helper/Typo3Screenshots.php
@@ -31,7 +31,7 @@ class Typo3Screenshots extends Module
     protected $config = [
         'actionsIdFilter' => '',
         'basePath' => '',
-        'documentationPath' => 'Documentation',
+        'documentationPath' => '',
         'imagePath' => 'Images/AutomaticScreenshots',
         'rstPath' => 'Images/Rst',
         'createRstFile' => true,

--- a/packages/screenshots/Classes/Util/FileHelper.php
+++ b/packages/screenshots/Classes/Util/FileHelper.php
@@ -20,12 +20,12 @@ class FileHelper
             $maxDepth--;
 
             if (is_dir($path)) {
-                $subFolders = scandir($path);
-                foreach ($subFolders as $subFolder) {
-                    $subPath = self::getRealPath($path . DIRECTORY_SEPARATOR . $subFolder);
-                    if (is_dir($subPath) && $subFolder != "." && $subFolder != "..") {
-                        $folders[] = $subPath;
-                        self::getFoldersRecursively($subPath, $maxDepth, $folders);
+                $folderNames = scandir($path);
+                foreach ($folderNames as $folderName) {
+                    $folderPath = self::getRealPath($path . DIRECTORY_SEPARATOR . $folderName);
+                    if (is_dir($folderPath) && $folderName != "." && $folderName != "..") {
+                        $folders[] = $folderPath;
+                        self::getFoldersRecursively($folderPath, $maxDepth, $folders);
                     }
                 }
             }
@@ -37,6 +37,31 @@ class FileHelper
     public static function getSubFolders(string $path): array
     {
         return self::getFoldersRecursively($path, 1);
+    }
+
+    public static function getFilesByNameRecursively(string $name, string $path, int $maxDepth = 999, array &$files = []): array
+    {
+        if ($maxDepth > 0) {
+            $maxDepth--;
+
+            if (is_dir($path)) {
+                $fileNames = scandir($path);
+                foreach ($fileNames as $fileName) {
+                    $filePath = self::getRealPath($path . DIRECTORY_SEPARATOR . $fileName);
+                    if (is_file($filePath)) {
+                        if ($fileName === $name) {
+                            $files[] = $filePath;
+                        }
+                    } else {
+                        if ($fileName != "." && $fileName != "..") {
+                            self::getFilesByNameRecursively($name, $filePath, $maxDepth, $files);
+                        }
+                    }
+                }
+            }
+        }
+
+        return $files;
     }
 
     public static function deleteRecursively(string $path): void

--- a/packages/screenshots/Tests/Unit/Runner/Codeception/Support/Helper/Typo3CodeSnippetsTest.php
+++ b/packages/screenshots/Tests/Unit/Runner/Codeception/Support/Helper/Typo3CodeSnippetsTest.php
@@ -67,27 +67,27 @@ class Typo3CodeSnippetsTest extends UnitTestCase
     {
         return [
             [
-                'sourceFile' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . '/code-snippet.json',
+                'sourceFile' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'code-snippet.json',
                 'targetFileName' => 'code-snippet-json',
-                'targetFilePath' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'Documentation/CodeSnippets/code-snippet-json.rst.txt',
+                'targetFilePath' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'CodeSnippets/code-snippet-json.rst.txt',
                 'expected' => 'code-block:: json'
             ],
             [
-                'sourceFile' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . '/code-snippet.php',
+                'sourceFile' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'code-snippet.php',
                 'targetFileName' => 'code-snippet-php',
-                'targetFilePath' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'Documentation/CodeSnippets/code-snippet-php.rst.txt',
+                'targetFilePath' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'CodeSnippets/code-snippet-php.rst.txt',
                 'expected' => 'code-block:: php'
             ],
             [
-                'sourceFile' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . '/code-snippet.xml',
+                'sourceFile' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'code-snippet.xml',
                 'targetFileName' => 'code-snippet-xml',
-                'targetFilePath' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'Documentation/CodeSnippets/code-snippet-xml.rst.txt',
+                'targetFilePath' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'CodeSnippets/code-snippet-xml.rst.txt',
                 'expected' => 'code-block:: xml'
             ],
             [
-                'sourceFile' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . '/code-snippet.yaml',
+                'sourceFile' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'code-snippet.yaml',
                 'targetFileName' => 'code-snippet-yaml',
-                'targetFilePath' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'Documentation/CodeSnippets/code-snippet-yaml.rst.txt',
+                'targetFilePath' => $this->vfsPathPlaceholder . DIRECTORY_SEPARATOR . 'CodeSnippets/code-snippet-yaml.rst.txt',
                 'expected' => 'code-block:: yaml'
             ]
         ];
@@ -98,7 +98,7 @@ class Typo3CodeSnippetsTest extends UnitTestCase
      */
     public function createCodeSnippetFailsIfCodeLanguageCannotBeDetermined(): void
     {
-        $sourceFile = $this->vfsPath . DIRECTORY_SEPARATOR . '/code-snippet.unknown';
+        $sourceFile = $this->vfsPath . DIRECTORY_SEPARATOR . 'code-snippet.unknown';
         $targetFileName = 'code-snippet-unkown';
 
         $this->createDummyCodeSnippet($sourceFile);

--- a/packages/screenshots/Tests/Unit/Util/FileHelperTest.php
+++ b/packages/screenshots/Tests/Unit/Util/FileHelperTest.php
@@ -77,6 +77,34 @@ class FileHelperTest extends UnitTestCase
     /**
      * @test
      */
+    public function getFilesByNameRecursively(): void
+    {
+        $folderTree = [
+            'FolderA' => [
+                'fileA.txt' => 'fileContentA'
+            ],
+            'FolderB' => [
+                'SubFolderA' => [
+                    'fileA.txt' => 'fileContentA'
+                ]
+            ],
+            'fileA.txt' => 'fileContentA',
+        ];
+        $expected = [
+            'vfs://t3docs/FolderA/fileA.txt',
+            'vfs://t3docs/FolderB/SubFolderA/fileA.txt',
+            'vfs://t3docs/fileA.txt',
+        ];
+
+        $root = vfsStream::setup('t3docs', null, $folderTree);
+        $actual = FileHelper::getFilesByNameRecursively('fileA.txt', $root->url());
+
+        self::assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function deleteRecursively(): void
     {
         $folderTree = [


### PR DESCRIPTION
The `screenshots.json` files are now found at any folder depth in `public/t3docs`.

Before:
- public/t3docs/TYPO3CMS-Book-ExtbaseFluid/screenshots.json => found
- public/t3docs/extension_builder/Documentation/screenshots.json => **not found**
- public/t3docs/typo3/typo3/sysext/impexp/Documentation/screenshots.json => **not found**

Now:
- public/t3docs/TYPO3CMS-Book-ExtbaseFluid/screenshots.json => found
- public/t3docs/extension_builder/Documentation/screenshots.json => found
- public/t3docs/typo3/typo3/sysext/impexp/Documentation/screenshots.json => found

Fixes: #220 