### PR TITLE
[FEATURE] Add TYPO3 environment "ExtensionBuilder" 

### DIFF
--- a/.ddev/commands/host/install
+++ b/.ddev/commands/host/install
@@ -3,7 +3,7 @@
 ## Description: (Re-)install the project or a single suite
 ## Usage: install [flags]
 ## Example: ddev install\nddev install --force\nddev install --suite-id site-package\nddev install --initialize-suites-only\nddev install --initialize-suites-only --suite-id site-package
-## Flags: [{"Name":"force","Shorthand":"f","Usage":"Do not ask any interactive question"},{"Name":"initialize-suites-only","Shorthand":"i","Usage":"Reflect updates of the project composer packages in the suites TYPO3 instances only instead of full (re-)installation."},{"Name":"suite-id","Shorthand":"s","Type":"string","Usage":"Re-install this suite only (core, examples, install, introduction, site-package, styleguide). All suites if empty."}]
+## Flags: [{"Name":"force","Shorthand":"f","Usage":"Do not ask any interactive question"},{"Name":"initialize-suites-only","Shorthand":"i","Usage":"Reflect updates of the project composer packages in the suites TYPO3 instances only instead of full (re-)installation."},{"Name":"suite-id","Shorthand":"s","Type":"string","Usage":"Re-install this suite only (core, examples, extension-builder, install, introduction, site-package, styleguide). All suites if empty."}]
 
 # Initialize local variables
 FORCE=""

--- a/.ddev/commands/web/fetch-manuals
+++ b/.ddev/commands/web/fetch-manuals
@@ -2,14 +2,60 @@
 
 ## Description: Fetch all official TYPO3 Documentation manuals
 ## Usage: fetch-manuals
-## Example: fetch-manuals
+## Example: fetch-manuals\nfetch-manuals -c documentation
+## Flags: [{"Name":"category","Shorthand":"c","Type":"string","Usage":"Clone only manuals of the selected category (documentation, application). Manuals of all categories if empty."}]
 
 TARGET_BASEPATH="/var/www/html/public/t3docs"
+CATEGORY=""
+
+fetch_options() {
+    local params;
+    local exitStatus;
+
+    params=$(getopt --options c: --longoptions category: --name "$0" -- "$@")
+
+    exitStatus=$?
+    if [ $exitStatus -eq 0 ]; then
+        eval set -- "$params"
+
+        while true
+        do
+            case "$1" in
+                -c|--category)
+                    CATEGORY=$2
+                    shift 2
+                    ;;
+                --)
+                    shift
+                    ;;
+                "")
+                    break
+                    ;;
+                *)
+                    echo "Invalid argument: '$1'" >&2
+                    exitStatus=1
+                    shift
+                    ;;
+            esac
+        done
+    fi
+
+    if [ $exitStatus -ne 0 ]; then
+        echo "Call \"fetch-manuals --help\" to display help and valid options."
+        exit $exitStatus
+    fi
+}
 
 clone_manual() {
-    local repositoryUrl=$1
-    local branch=$2
-    local manualFolder=$3
+    local category=$1
+    local repositoryUrl=$2
+    local branch=$3
+    local manualFolder=$4
+
+    if [ "$CATEGORY" != "" ] && [ "$CATEGORY" != "$category" ]; then
+        echo "Skip cloning manual '$manualFolder'."
+        return 1
+    fi
 
     if [[ -d "$TARGET_BASEPATH/$manualFolder" ]]; then
         echo "Manual '$manualFolder' already exists."
@@ -28,18 +74,20 @@ clone_manual() {
 [[ ! -d "$TARGET_BASEPATH" ]] && mkdir "$TARGET_BASEPATH"
 cd "$TARGET_BASEPATH"
 
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Book-ExtbaseFluid" "master" "TYPO3CMS-Book-ExtbaseFluid"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Guide-ContributionWorkflow" "master" "TYPO3CMS-Guide-ContributionWorkflow"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Guide-FrontendLocalization" "master" "TYPO3CMS-Guide-FrontendLocalization"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument" "master" "TYPO3CMS-Guide-HowToDocument"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Guide-Installation" "master" "TYPO3CMS-Guide-Installation"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Reference-CoreApi" "master" "TYPO3CMS-Reference-CoreApi"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Reference-TCA" "master" "TYPO3CMS-Reference-TCA"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Reference-TSconfig" "master" "TYPO3CMS-Reference-TSconfig"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Reference-Typoscript" "master" "TYPO3CMS-Reference-Typoscript"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Tutorial-Editors" "master" "TYPO3CMS-Tutorial-Editors"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Tutorial-GettingStarted" "master" "TYPO3CMS-Tutorial-GettingStarted"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Tutorial-SitePackage" "master" "TYPO3CMS-Tutorial-SitePackage"
-clone_manual "git@github.com:TYPO3-Documentation/TYPO3CMS-Tutorial-Typoscript45Minutes" "master" "TYPO3CMS-Tutorial-Typoscript45Minutes"
+fetch_options $@
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Book-ExtbaseFluid" "master" "TYPO3CMS-Book-ExtbaseFluid"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Guide-ContributionWorkflow" "master" "TYPO3CMS-Guide-ContributionWorkflow"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Guide-FrontendLocalization" "master" "TYPO3CMS-Guide-FrontendLocalization"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument" "master" "TYPO3CMS-Guide-HowToDocument"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Guide-Installation" "master" "TYPO3CMS-Guide-Installation"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Reference-CoreApi" "master" "TYPO3CMS-Reference-CoreApi"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Reference-TCA" "master" "TYPO3CMS-Reference-TCA"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Reference-TSconfig" "master" "TYPO3CMS-Reference-TSconfig"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Reference-Typoscript" "master" "TYPO3CMS-Reference-Typoscript"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Tutorial-Editors" "master" "TYPO3CMS-Tutorial-Editors"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Tutorial-GettingStarted" "master" "TYPO3CMS-Tutorial-GettingStarted"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Tutorial-SitePackage" "master" "TYPO3CMS-Tutorial-SitePackage"
+clone_manual "documentation" "git@github.com:TYPO3-Documentation/TYPO3CMS-Tutorial-Typoscript45Minutes" "master" "TYPO3CMS-Tutorial-Typoscript45Minutes"
+clone_manual "application" "git@github.com:FriendsOfTYPO3/extension_builder" "master" "extension_builder"
 
 cd - > /dev/null

--- a/.ddev/commands/web/make-screenshots
+++ b/.ddev/commands/web/make-screenshots
@@ -3,7 +3,7 @@
 ## Description: Make screenshots via codeception inside the web container
 ## Usage: make-screenshots
 ## Example: make-screenshots\nmake-screenshots -s Styleguide\nmake-screenshots -s Styleguide -a actionsIdentifierScreenshots\nmake-screenshots -t TYPO3CMS-Reference-TCA
-## Flags: [{"Name":"actions-id","Shorthand":"a","Type":"string","Usage":"Run actions of specific ID only. Actions of all IDs if empty."},{"Name":"suite-id","Shorthand":"s","Type":"string","Usage":"Run actions of specific TYPO3 environment suite ID only (Core, Examples, Install, Introduction, SitePackage, Styleguide). All suites if empty."},{"Name":"target-path","Shorthand":"t","Type":"string","Usage":"Run actions of specific folder and its subfolders only (relative or absolute path). All folders if empty."}]
+## Flags: [{"Name":"actions-id","Shorthand":"a","Type":"string","Usage":"Run actions of specific ID only. Actions of all IDs if empty."},{"Name":"suite-id","Shorthand":"s","Type":"string","Usage":"Run actions of specific TYPO3 environment suite ID only (Core, Examples, ExtensionBuilder, Install, Introduction, SitePackage, Styleguide). All suites if empty."},{"Name":"target-path","Shorthand":"t","Type":"string","Usage":"Run actions of specific folder and its subfolders only (relative or absolute path). All folders if empty."}]
 
 SUITE_ID=""
 TARGET_PATH=""

--- a/.ddev/config.suites.yaml
+++ b/.ddev/config.suites.yaml
@@ -1,6 +1,7 @@
 additional_hostnames:
     - "core.t3docs-screenshots"
     - "examples.t3docs-screenshots"
+    - "extension-builder.t3docs-screenshots"
     - "install.t3docs-screenshots"
     - "introduction.t3docs-screenshots"
     - "site-package.t3docs-screenshots"

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,8 @@ or by resetting a single suite TYPO3 instance with
 
    ddev install -s [suite-id]
 
-again. Available suite IDs are "core", "examples", "install", "introduction", "site-package" and "styleguide".
+again. Available suite IDs are "core", "examples", "extension-builder", "install", "introduction", "site-package" and
+"styleguide".
 
 Synchronizing
 -------------
@@ -150,6 +151,7 @@ Browsable TYPO3 instances
    -  Screenshots manager: https://t3docs-screenshots.ddev.site/typo3
    -  Suite "Core": https://core.t3docs-screenshots.ddev.site/typo3
    -  Suite "Examples": https://examples.t3docs-screenshots.ddev.site/typo3
+   -  Suite "Extension Builder": https://extension-builder.t3docs-screenshots.ddev.site/typo3
    -  Suite "Install": https://install.t3docs-screenshots.ddev.site
    -  Suite "Introduction": https://introduction.t3docs-screenshots.ddev.site/typo3
    -  Suite "Site Package": https://site-package.t3docs-screenshots.ddev.site/typo3
@@ -200,7 +202,8 @@ File ``screenshots.json``
 
 The runner configuration file ``screenshots.json`` must be placed in the root directory of the respective documentation
 folder, i.e. in ``public/t3docs/*/screenshots.json``. It defines in the first level the suite
-("Core", "Examples", "Install", "Introduction", "SitePackage" or "Styleguide") where the screenshots are taken,
+("Core", "Examples", "ExtensionBuilder", "Install", "Introduction", "SitePackage" or "Styleguide")
+where the screenshots are taken,
 and in the second level it lists blocks of browser actions. Each action is an object, where the key ``action`` marks
 the action name and the remaining keys represent the action parameters.
 Actions are mainly about navigating the suite TYPO3 instance and taking screenshots.
@@ -230,6 +233,15 @@ This is a small runner configuration which takes screenshots of all available su
             "screenshots": [
                [
                   {"action": "makeScreenshotOfFullPage", "fileName": "ExamplesDashboardFullPage"}
+               ]
+            ]
+         },
+         "ExtensionBuilder": {
+            "screenshots": [
+               [
+                  {"action": "see", "text": "Extension Builder"},
+                  {"action": "click", "link": "Extension Builder"},
+                  {"action": "makeScreenshotOfFullPage", "fileName": "ExtensionBuilderFullPage"}
                ]
             ]
          },
@@ -628,6 +640,13 @@ Make screenshots of TYPO3 backend + EXT:examples
 .. code-block:: bash
 
    ddev make-screenshots -s Examples
+
+Make screenshots of TYPO3 backend + EXT:extension_builder
+---------------------------------------------------------
+
+.. code-block:: bash
+
+   ddev make-screenshots -s ExtensionBuilder
 
 Make screenshots of TYPO3 backend + EXT:introduction
 ----------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -173,13 +173,27 @@ Folders in ``public/t3docs``
 ----------------------------
 
 The folders in ``public/t3docs`` should contain the official TYPO3 Documentation manuals or other documentation that
-needs fresh screenshots of TYPO3. Get all official TYPO3 Documentation manuals in one bundle (requires access
-permission) by
+needs fresh screenshots of TYPO3. Get all official TYPO3 Documentation manuals and other officially supported TYPO3
+projects in one bundle (requires access permission) by
 
 .. code-block:: bash
 
    ddev auth ssh
    ddev fetch-manuals
+
+or limit it to either the official TYPO3 Documentation manuals with
+
+.. code-block:: bash
+
+   ddev auth ssh
+   ddev fetch-manuals -c documentation
+
+or the officially supported TYPO3 projects with
+
+.. code-block:: bash
+
+   ddev auth ssh
+   ddev fetch-manuals -c application
 
 File ``screenshots.json``
 -------------------------

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
         "codeception/codeception": "^4.1.12",
         "codeception/module-webdriver": "^1.1.4",
         "cweagans/composer-patches": "^1.7",
+        "friendsoftypo3/extension-builder": "dev-master",
         "sebastian/diff": "^4.0",
         "sensiolabs/ansi-to-html": "^1.2",
         "t3docs/examples": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33f1836349015adc7a5a24bd86ff9f27",
+    "content-hash": "6c97f96343b14bffe8fe02de0ff244ac",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5011,7 +5011,7 @@
         },
         {
             "name": "t3docs/screenshots-suites",
-            "version": "dev-main",
+            "version": "dev-feature-add-extension-builder-suite",
             "dist": {
                 "type": "path",
                 "url": "packages/screenshots-suites",
@@ -8143,6 +8143,81 @@
             "time": "2021-06-08T15:12:46+00:00"
         },
         {
+            "name": "friendsoftypo3/extension-builder",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfTYPO3/extension_builder.git",
+                "reference": "542dd193f6c21857738843462ee9ea9ce8a4a676"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfTYPO3/extension_builder/zipball/542dd193f6c21857738843462ee9ea9ce8a4a676",
+                "reference": "542dd193f6c21857738843462ee9ea9ce8a4a676",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "nikic/php-parser": "^4.10.4",
+                "php": "^7.4 || ^8.0",
+                "typo3/cms-backend": "^11.4",
+                "typo3/cms-core": "^11.4"
+            },
+            "replace": {
+                "typo3-ter/extension-builder": "self.version"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.18",
+                "roave/security-advisories": "dev-latest",
+                "sebastian/diff": "^3.0",
+                "typo3/cms-frontend": "^11.4",
+                "typo3/cms-install": "^11.4",
+                "typo3/coding-standards": "^0.3.0",
+                "typo3/testing-framework": "^6.11"
+            },
+            "default-branch": true,
+            "type": "typo3-cms-extension",
+            "extra": {
+                "typo3/cms": {
+                    "extension-key": "extension_builder",
+                    "cms-package-dir": "{$vendor-dir}/typo3/cms",
+                    "app-dir": ".Build",
+                    "web-dir": ".Build/public"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "EBT\\ExtensionBuilder\\": "Classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Nico de Haen",
+                    "role": "Developer"
+                },
+                {
+                    "name": "extension_builder Development Team",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Tool to kickstart and maintain TYPO3 extensions",
+            "homepage": "https://github.com/FriendsOfTYPO3/extension_builder",
+            "keywords": [
+                "extension",
+                "extension_builder",
+                "typo3"
+            ],
+            "support": {
+                "issues": "https://github.com/FriendsOfTYPO3/extension_builder/issues",
+                "source": "https://github.com/FriendsOfTYPO3/extension_builder/tree/v11.0.0"
+            },
+            "time": "2021-10-06T14:53:54+00:00"
+        },
+        {
             "name": "mikey179/vfsstream",
             "version": "v1.6.10",
             "source": {
@@ -10134,7 +10209,7 @@
         },
         {
             "name": "t3docs/screenshots",
-            "version": "dev-main",
+            "version": "dev-feature-add-extension-builder-suite",
             "dist": {
                 "type": "path",
                 "url": "packages/screenshots",
@@ -10798,6 +10873,7 @@
         "typo3/cms-t3editor": 20,
         "typo3/cms-tstemplate": 20,
         "typo3/cms-viewpage": 20,
+        "friendsoftypo3/extension-builder": 20,
         "t3docs/examples": 20,
         "t3docs/screenshots": 20,
         "typo3/cms-introduction": 20,

--- a/packages/screenshots/Classes/Command/FetchSuitesCommand.php
+++ b/packages/screenshots/Classes/Command/FetchSuitesCommand.php
@@ -45,7 +45,7 @@ class FetchSuitesCommand extends Command
                 'suite-id',
                 's',
                 InputOption::VALUE_OPTIONAL,
-                'Filter for specific suite ID (Core, Examples, Install, Introduction, SitePackage, Styleguide). ' .
+                'Filter for specific suite ID (Core, Examples, ExtensionBuilder, Install, Introduction, SitePackage, Styleguide). ' .
                 'All suite IDs if empty.'
             )
             ->addOption(

--- a/packages/screenshots/Classes/Configuration/Configuration.php
+++ b/packages/screenshots/Classes/Configuration/Configuration.php
@@ -239,6 +239,19 @@ class Configuration
                         ]
                     ]
                 ],
+                'ExtensionBuilder' => [
+                    'screenshots' => [
+                        '_default'=> [
+                            ['action' => 'resizeWindow', 'width' => 1024, 'height' => 768],
+                        ],
+                        'actionsIdentifierExtensionBuilder' => [
+                            ['include' => '_default'],
+                            ['action' => 'see', 'text' => 'Extension Builder'],
+                            ['action' => 'click', 'link' => 'Extension Builder'],
+                            ['action' => 'makeScreenshotOfFullPage', 'fileName' => 'ExtensionBuilderFullPage'],
+                        ]
+                    ]
+                ],
                 'Install' => [
                     'screenshots' => [
                         [

--- a/packages/screenshots/Classes/Controller/ScreenshotsManagerController.php
+++ b/packages/screenshots/Classes/Controller/ScreenshotsManagerController.php
@@ -44,7 +44,7 @@ class ScreenshotsManagerController extends ActionController
 
         $this->pageRenderer->addInlineLanguageLabelFile('EXT:screenshots/Resources/Private/Language/locallang_mod.xlf');
         $this->pageRenderer->addCssFile('EXT:screenshots/Resources/Public/Css/screenshots-manager.css');
-        $this->pageRenderer->loadRequireJsModule('TYPO3/Documentation/Screenshots/ScreenshotsManager');
+        $this->pageRenderer->loadRequireJsModule('TYPO3/CMS/Screenshots/ScreenshotsManager');
     }
 
     public function indexAction()

--- a/packages/screenshots/Classes/Runner/Codeception/ExtensionBuilder/ExtensionBuilderCest.php
+++ b/packages/screenshots/Classes/Runner/Codeception/ExtensionBuilder/ExtensionBuilderCest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\Documentation\Screenshots\Runner\Codeception\ExtensionBuilder;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\Documentation\Screenshots\Runner\Codeception\AbstractBaseCest;
+use TYPO3\Documentation\Screenshots\Runner\Codeception\Support\Photographer;
+
+/**
+ * Run all actions of TYPO3 environment "ExtensionBuilder"
+ */
+class ExtensionBuilderCest extends AbstractBaseCest
+{
+    /**
+     * @param Photographer $I
+     */
+    public function makeScreenshots(Photographer $I): void
+    {
+        $I->reloadBackend('admin');
+        parent::runSuite($I, 'ExtensionBuilder');
+    }
+}

--- a/packages/screenshots/Classes/Runner/Codeception/Support/Extension/ExtensionBuilderEnvironment.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Extension/ExtensionBuilderEnvironment.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+namespace TYPO3\Documentation\Screenshots\Runner\Codeception\Support\Extension;
+
+/*
+ * This file is part of the TYPO3 project.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Codeception\Event\SuiteEvent;
+use TYPO3\CMS\Core\Core\ApplicationContext;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Extensionmanager\Utility\InstallUtility;
+use TYPO3\TestingFramework\Core\Acceptance\Extension\BackendEnvironment;
+
+/**
+ * Load all core extensions and EXT:extension_builder and EXT:screenshots
+ */
+class ExtensionBuilderEnvironment extends BackendEnvironment
+{
+    /**
+     * @var array
+     */
+    protected $localConfig = [
+        // Order matters: Align sorting of core extensions with /public/typo3conf/PackageStates.php
+        'coreExtensionsToLoad' => [
+            'core',
+            'scheduler',
+            'extbase',
+            'fluid',
+            'frontend',
+            'fluid_styled_content',
+            'filelist',
+            'impexp',
+            'form',
+            'install',
+            'info',
+            'linkvalidator',
+            'reports',
+            'redirects',
+            'recordlist',
+            'backend',
+            'indexed_search',
+            'recycler',
+            'setup',
+            'rte_ckeditor',
+            'adminpanel',
+            'belog',
+            'beuser',
+            'dashboard',
+            'extensionmanager',
+            'felogin',
+            'filemetadata',
+            'lowlevel',
+            'opendocs',
+            'seo',
+            'sys_note',
+            't3editor',
+            'tstemplate',
+            'viewpage',
+        ],
+        'testExtensionsToLoad' => [
+            'typo3conf/ext/extension_builder',
+            'typo3conf/ext/screenshots',
+        ],
+        'xmlDatabaseFixtures' => [
+            'EXT:screenshots/Classes/Runner/Codeception/Fixtures/StyleguideEnvironment/be_groups.xml',
+            'EXT:screenshots/Classes/Runner/Codeception/Fixtures/StyleguideEnvironment/be_sessions.xml',
+            'EXT:screenshots/Classes/Runner/Codeception/Fixtures/StyleguideEnvironment/be_users.xml',
+        ],
+    ];
+
+    /**
+     * Initialize TYPO3 instance
+     *
+     * @param SuiteEvent $suiteEvent
+     */
+    public function bootstrapTypo3Environment(SuiteEvent $suiteEvent): void
+    {
+        parent::bootstrapTypo3Environment($suiteEvent);
+
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            Environment::isCli(),
+            Environment::isComposerMode(),
+            Environment::getProjectPath(),
+            Environment::getPublicPath(),
+            Environment::getVarPath(),
+            Environment::getConfigPath(),
+            Environment::getBackendPath() . '/index.php',
+            Environment::isWindows() ? 'WINDOWS' : 'UNIX'
+        );
+    }
+}

--- a/packages/screenshots/Classes/Runner/codeception.yml
+++ b/packages/screenshots/Classes/Runner/codeception.yml
@@ -23,6 +23,18 @@ suites:
     extensions:
       enabled:
         - TYPO3\Documentation\Screenshots\Runner\Codeception\Support\Extension\ExamplesEnvironment
+  ExtensionBuilder:
+    actor: Photographer
+    modules:
+      enabled:
+        - TYPO3\TestingFramework\Core\Acceptance\Helper\Login:
+            sessions:
+              # This sessions must exist in the database fixture to get a logged in state.
+              admin: 886526ce72b86870739cc41991144ec1
+              editor: ff83dfd81e20b34c27d3e97771a4525a
+    extensions:
+      enabled:
+        - TYPO3\Documentation\Screenshots\Runner\Codeception\Support\Extension\ExtensionBuilderEnvironment
   Install:
     actor: Photographer
     extensions:

--- a/packages/screenshots/Resources/Private/Templates/ScreenshotsManager/Make.html
+++ b/packages/screenshots/Resources/Private/Templates/ScreenshotsManager/Make.html
@@ -24,7 +24,7 @@
                 <f:form.select
                     id="screenshotsSuite"
                     name="suiteIdFilter"
-                    options="{Core: 'Core (TYPO3 backend)', Examples: 'Examples (TYPO3 backend + EXT:examples)', Install: 'Install (TYPO3 installation process)', Introduction: 'Introduction (TYPO3 backend + EXT:introduction)', SitePackage: 'Site Package (TYPO3 backend + EXT:site_package)', Styleguide: 'Styleguide (TYPO3 backend + EXT:styleguide)'}"
+                    options="{Core: 'Core (TYPO3 backend)', Examples: 'Examples (TYPO3 backend + EXT:examples)', ExtensionBuilder: 'Extension Builder (TYPO3 backend + EXT:extension_builder)', Install: 'Install (TYPO3 installation process)', Introduction: 'Introduction (TYPO3 backend + EXT:introduction)', SitePackage: 'Site Package (TYPO3 backend + EXT:site_package)', Styleguide: 'Styleguide (TYPO3 backend + EXT:styleguide)'}"
                     prependOptionLabel="All"
                     prependOptionValue=""
                     value="{suiteIdFilter}"

--- a/packages/screenshots/Tests/Unit/Command/FetchSuitesCommandTest.php
+++ b/packages/screenshots/Tests/Unit/Command/FetchSuitesCommandTest.php
@@ -41,6 +41,7 @@ class FetchSuitesCommandTest extends UnitTestCase
             [
                 ['path' => $vfsPath, 'suiteId' => 'Core'],
                 ['path' => $vfsPath, 'suiteId' => 'Examples'],
+                ['path' => $vfsPath, 'suiteId' => 'ExtensionBuilder'],
                 ['path' => $vfsPath, 'suiteId' => 'Install'],
                 ['path' => $vfsPath, 'suiteId' => 'Introduction'],
                 ['path' => $vfsPath, 'suiteId' => 'SitePackage'],

--- a/packages/screenshots/Tests/Unit/Configuration/ConfigurationTest.php
+++ b/packages/screenshots/Tests/Unit/Configuration/ConfigurationTest.php
@@ -147,6 +147,7 @@ class ConfigurationTest extends UnitTestCase
         $expectedActionsIds = [
             'actionsIdentifierExamplesFrontend',
             'actionsIdentifierExamplesBackend',
+            'actionsIdentifierExtensionBuilder',
             'actionsIdentifierIntroductionFrontend',
             'actionsIdentifierIntroductionBackend',
             'actionsIdentifierIntroductionUserSwitch',

--- a/packages/screenshots/Tests/unit.xml
+++ b/packages/screenshots/Tests/unit.xml
@@ -11,6 +11,7 @@
         <exclude>
             <directory>../Classes/Runner/Codeception/Core</directory>
             <directory>../Classes/Runner/Codeception/Examples</directory>
+            <directory>../Classes/Runner/Codeception/ExtensionBuilder</directory>
             <directory>../Classes/Runner/Codeception/Install</directory>
             <directory>../Classes/Runner/Codeception/Introduction</directory>
             <directory>../Classes/Runner/Codeception/SitePackage</directory>

--- a/suites/extension-builder/dist.json
+++ b/suites/extension-builder/dist.json
@@ -10,5 +10,5 @@
             "cp res/AdditionalConfiguration.php public/typo3conf/"
         ]
     },
-    "extra": []
+    "extra": {}
 }

--- a/suites/extension-builder/dist.json
+++ b/suites/extension-builder/dist.json
@@ -1,0 +1,14 @@
+{
+    "name": "t3docs/screenshots-extension-builder",
+    "description" : "TYPO3 Screenshots Extension Builder",
+    "require-dev": {
+        "friendsoftypo3/extension-builder": "dev-master"
+    },
+    "scripts": {
+        "setup-suite": [
+            "typo3cms install:setup --no-interaction --database-user-name root --database-user-password root --database-host-name db --admin-user-name admin --admin-password password --site-setup-type site",
+            "cp res/AdditionalConfiguration.php public/typo3conf/"
+        ]
+    },
+    "extra": []
+}

--- a/suites/extension-builder/res/AdditionalConfiguration.php
+++ b/suites/extension-builder/res/AdditionalConfiguration.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Nginx terminates SSL, so TYPO3 struggles with verifying the request port (443 <-> 80).
+ * Allow any port by passing here the domain name without defining the port.
+ */
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = 'extension-builder\.t3docs-screenshots\.ddev\.site';

--- a/suites/site-package/dist.json
+++ b/suites/site-package/dist.json
@@ -2,7 +2,7 @@
     "name": "t3docs/screenshots-site-package",
     "description" : "TYPO3 Screenshots Site Package",
     "require-dev": {
-        "typo3/site-package": "dev-lwolf-v11"
+        "typo3/site-package": "dev-master"
     },
     "scripts": {
         "setup-suite": [
@@ -10,5 +10,5 @@
             "cp res/AdditionalConfiguration.php public/typo3conf/"
         ]
     },
-    "extra": []
+    "extra": {}
 }


### PR DESCRIPTION
Add a `TYPO3 + EXT:extension_builder` environment which can provide screenshots for the extension documentation.

Fixes: #224 
Requires: #223 