### PR TITLE
[FEATURE] Generate frontend pages of EXT:styleguide

### DIFF
--- a/packages/screenshots/Classes/Runner/Codeception/Support/Extension/StyleguideEnvironment.php
+++ b/packages/screenshots/Classes/Runner/Codeception/Support/Extension/StyleguideEnvironment.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\Core\Core\ApplicationContext;
 use TYPO3\CMS\Core\Core\Bootstrap;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Styleguide\TcaDataGenerator\Generator;
+use TYPO3\CMS\Styleguide\TcaDataGenerator\GeneratorFrontend;
 use TYPO3\TestingFramework\Core\Acceptance\Extension\BackendEnvironment;
 
 /**
@@ -112,5 +113,7 @@ class StyleguideEnvironment extends BackendEnvironment
 
         $styleguideGenerator = new Generator();
         $styleguideGenerator->create();
+        $styleguideGeneratorFrontend = new GeneratorFrontend();
+        $styleguideGeneratorFrontend->create();
     }
 }


### PR DESCRIPTION
EXT:styleguide introduced a second Generator TYPO3\CMS\Styleguide\TcaDataGenerator\GeneratorFrontend a while ago.
It creates a second page tree containing examples of all content elements provided by the Core. I need them for https://review.typo3.org/c/Packages/TYPO3.CMS/+/72164 for example.